### PR TITLE
Drupal 8.7.14

### DIFF
--- a/core/assets/vendor/jquery/jquery-htmlprefilter-3.5.0.js
+++ b/core/assets/vendor/jquery/jquery-htmlprefilter-3.5.0.js
@@ -1,0 +1,104 @@
+/**
+ * For jQuery versions less than 3.5.0, this replaces the jQuery.htmlPrefilter()
+ * function with one that fixes these security vulnerabilities while also
+ * retaining the pre-3.5.0 behavior where it's safe to do so.
+ * - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-11022
+ * - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-11023
+ */
+
+(function (jQuery) {
+
+  // No backport is needed if we're already on jQuery 3.5 or higher.
+  var versionParts = jQuery.fn.jquery.split('.');
+  var majorVersion = parseInt(versionParts[0]);
+  var minorVersion = parseInt(versionParts[1]);
+  if ( (majorVersion > 3) || (majorVersion === 3 && minorVersion >= 5) ) {
+    return;
+  }
+
+  // Prior to jQuery 3.5, jQuery converted XHTML-style self-closing tags to
+  // their XML equivalent: e.g., "<div />" to "<div></div>". This is
+  // problematic for several reasons, including that it's vulnerable to XSS
+  // attacks. However, since this was jQuery's behavior for many years, many
+  // Drupal modules and jQuery plugins may be relying on it. Therefore, we
+  // preserve that behavior, but for a limited set of tags only, that we believe
+  // to not be vulnerable. This is the set of HTML tags that satisfy all of the
+  // following conditions:
+  // - In DOMPurify's list of HTML tags. If an HTML tag isn't safe enough to
+  //   appear in that list, then we don't want to mess with it here either.
+  //   @see https://github.com/cure53/DOMPurify/blob/2.0.11/dist/purify.js#L128
+  // - A normal element (not a void, template, text, or foreign element).
+  //   @see https://html.spec.whatwg.org/multipage/syntax.html#elements-2
+  // - An element that is still defined by the current HTML specification
+  //   (not a deprecated element), because we do not want to rely on how
+  //   browsers parse deprecated elements.
+  //   @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element
+  // - Not 'html', 'head', or 'body', because this pseudo-XHTML expansion is
+  //   designed for fragments, not entire documents.
+  // - Not 'colgroup', because due to an idiosyncrasy of jQuery's original
+  //   regular expression, it didn't match on colgroup, and we don't want to
+  //   introduce a behavior change for that.
+  var selfClosingTagsToReplace = [
+    'a', 'abbr', 'address', 'article', 'aside', 'audio', 'b', 'bdi', 'bdo',
+    'blockquote', 'button', 'canvas', 'caption', 'cite', 'code', 'data',
+    'datalist', 'dd', 'del', 'details', 'dfn', 'div', 'dl', 'dt', 'em',
+    'fieldset', 'figcaption', 'figure', 'footer', 'form', 'h1', 'h2', 'h3',
+    'h4', 'h5', 'h6', 'header', 'hgroup', 'i', 'ins', 'kbd', 'label', 'legend',
+    'li', 'main', 'map', 'mark', 'menu', 'meter', 'nav', 'ol', 'optgroup',
+    'option', 'output', 'p', 'picture', 'pre', 'progress', 'q', 'rp', 'rt',
+    'ruby', 's', 'samp', 'section', 'select', 'small', 'source', 'span',
+    'strong', 'sub', 'summary', 'sup', 'table', 'tbody', 'td', 'tfoot', 'th',
+    'thead', 'time', 'tr', 'u', 'ul', 'var', 'video'
+  ];
+
+  // Define regular expressions for <TAG/> and <TAG ATTRIBUTES/>. Doing this as
+  // two expressions makes it easier to target <a/> without also targeting
+  // every tag that starts with "a".
+  var xhtmlRegExpGroup = '(' + selfClosingTagsToReplace.join('|') + ')';
+  var whitespace = '[\\x20\\t\\r\\n\\f]';
+  var rxhtmlTagWithoutSpaceOrAttributes = new RegExp('<' + xhtmlRegExpGroup + '\\/>', 'gi');
+  var rxhtmlTagWithSpaceAndMaybeAttributes = new RegExp('<' + xhtmlRegExpGroup + '(' + whitespace + '[^>]*)\\/>', 'gi');
+
+  // jQuery 3.5 also fixed a vulnerability for when </select> appears within
+  // an <option> or <optgroup>, but it did that in local code that we can't
+  // backport directly. Instead, we filter such cases out. To do so, we need to
+  // determine when jQuery would otherwise invoke the vulnerable code, which it
+  // uses this regular expression to determine. The regular expression changed
+  // for version 3.4.0.
+  // @see https://github.com/jquery/jquery/blob/3.2.1/dist/jquery.js#L4695
+  // @see https://github.com/jquery/jquery/blob/3.4.0/dist/jquery.js#L4712
+  var rtagName;
+  if (minorVersion < 4) {
+    rtagName = /<([a-z][^\/\0>\x20\t\r\n\f]+)/i;
+  }
+  else {
+    rtagName = /<([a-z][^\/\0>\x20\t\r\n\f]*)/i;
+  }
+
+  jQuery.extend({
+    htmlPrefilter: function (html) {
+      // This is how jQuery determines the first tag in the HTML.
+      // @see https://github.com/jquery/jquery/blob/3.2.1/dist/jquery.js#L4794
+      var tag = ( rtagName.exec( html ) || [ "", "" ] )[ 1 ].toLowerCase();
+
+      // It is not valid HTML for <option> or <optgroup> to have <select> as
+      // either a descendant or sibling, and attempts to inject one can cause
+      // XSS on jQuery versions before 3.5. Since this is invalid HTML and a
+      // possible XSS attack, reject the entire string.
+      // @see https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-11023
+      if ((tag === 'option' || tag === 'optgroup') && html.match(/<\/?select/i)) {
+        html = '';
+      }
+
+      // Retain jQuery 3.2's conversion of pseudo-XHTML, but for only the
+      // tags in the `selfClosingTagsToReplace` list defined above.
+      // @see https://github.com/jquery/jquery/blob/3.2.1/dist/jquery.js#L5822
+      // @see https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-11022
+      html = html.replace(rxhtmlTagWithoutSpaceOrAttributes, "<$1></$1>");
+      html = html.replace(rxhtmlTagWithSpaceAndMaybeAttributes, "<$1$2></$1>");
+
+      return html;
+    }
+  });
+
+})(jQuery);

--- a/core/core.libraries.yml
+++ b/core/core.libraries.yml
@@ -356,9 +356,11 @@ jquery:
     gpl-compatible: true
   js:
     assets/vendor/jquery/jquery.min.js: { minified: true, weight: -20 }
-    # This includes a security fix, so assign a weight that makes this load as
-    # soon after jquery.min.js is loaded as possible.
+    # These include security fixes, so assign a weight that makes them load as
+    # soon after jquery.min.js is loaded as possible. Their relative order to
+    # each other doesn't matter.
     assets/vendor/jquery/jquery-extend-3.4.0.js: { weight: -19 }
+    assets/vendor/jquery/jquery-htmlprefilter-3.5.0.js: { weight: -19 }
 
 jquery.cookie:
   remote: https://github.com/carhartl/jquery-cookie

--- a/core/includes/install.inc
+++ b/core/includes/install.inc
@@ -80,9 +80,13 @@ const FILE_NOT_EXECUTABLE = 128;
  * Loads .install files for installed modules to initialize the update system.
  */
 function drupal_load_updates() {
+  /** @var \Drupal\Core\Extension\ModuleExtensionList $extension_list_module */
+  $extension_list_module = \Drupal::service('extension.list.module');
   foreach (drupal_get_installed_schema_version(NULL, FALSE, TRUE) as $module => $schema_version) {
-    if ($schema_version > -1) {
-      module_load_install($module);
+    if ($extension_list_module->exists($module) && !$extension_list_module->checkIncompatibility($module)) {
+      if ($schema_version > -1) {
+        module_load_install($module);
+      }
     }
   }
 }

--- a/core/includes/update.inc
+++ b/core/includes/update.inc
@@ -14,8 +14,13 @@ use Drupal\Core\Utility\Error;
 
 /**
  * Disables any extensions that are incompatible with the current core version.
+ *
+ * @deprecated in Drupal 8.8.4 and is removed from Drupal 9.0.0.
+ *
+ * @see https://www.drupal.org/node/3026100
  */
 function update_fix_compatibility() {
+  @trigger_error(__FUNCTION__ . '() is deprecated in Drupal 8.8.4 and will be removed before Drupal 9.0.0. There is no replacement. See https://www.drupal.org/node/3026100', E_USER_DEPRECATED);
   // Fix extension objects if the update is being done via Drush 8. In non-Drush
   // environments this will already be fixed by the UpdateKernel this point.
   UpdateKernel::fixSerializedExtensionObjects(\Drupal::getContainer());
@@ -306,9 +311,11 @@ function update_get_update_list() {
   $ret = ['system' => []];
 
   $modules = drupal_get_installed_schema_version(NULL, FALSE, TRUE);
+  /** @var \Drupal\Core\Extension\ExtensionList $extension_list */
+  $extension_list = \Drupal::service('extension.list.module');
   foreach ($modules as $module => $schema_version) {
     // Skip uninstalled and incompatible modules.
-    if ($schema_version == SCHEMA_UNINSTALLED || update_check_incompatibility($module)) {
+    if ($schema_version == SCHEMA_UNINSTALLED || $extension_list->checkIncompatibility($module)) {
       continue;
     }
     // Display a requirements error if the user somehow has a schema version

--- a/core/lib/Drupal.php
+++ b/core/lib/Drupal.php
@@ -82,7 +82,7 @@ class Drupal {
   /**
    * The current system version.
    */
-  const VERSION = '8.7.12';
+  const VERSION = '8.7.14';
 
   /**
    * Core API compatibility.

--- a/core/lib/Drupal/Core/Entity/Sql/SqlContentEntityStorageSchema.php
+++ b/core/lib/Drupal/Core/Entity/Sql/SqlContentEntityStorageSchema.php
@@ -427,7 +427,8 @@ class SqlContentEntityStorageSchema implements DynamicallyFieldableEntityStorage
     $schema_handler = $this->database->schema();
 
     // Delete entity and field tables.
-    foreach ($this->getTableMapping($entity_type)->getTableNames() as $table_name) {
+    $table_names = $this->getTableNames($entity_type, $this->fieldStorageDefinitions, $this->getTableMapping($entity_type));
+    foreach ($table_names as $table_name) {
       if ($schema_handler->tableExists($table_name)) {
         $schema_handler->dropTable($table_name);
       }
@@ -465,7 +466,10 @@ class SqlContentEntityStorageSchema implements DynamicallyFieldableEntityStorage
 
     // Create temporary tables based on the new entity type and field storage
     // definitions.
-    $temporary_table_names = array_combine($sandbox['new_table_mapping']->getTableNames(), $sandbox['temporary_table_mapping']->getTableNames());
+    $temporary_table_names = array_combine(
+      $this->getTableNames($entity_type, $field_storage_definitions, $sandbox['new_table_mapping']),
+      $this->getTableNames($entity_type, $field_storage_definitions, $sandbox['temporary_table_mapping'])
+    );
     $this->entityType = $entity_type;
     $this->fieldStorageDefinitions = $field_storage_definitions;
 
@@ -505,14 +509,15 @@ class SqlContentEntityStorageSchema implements DynamicallyFieldableEntityStorage
     $this->storage->setEntityType($original);
     $this->storage->setFieldStorageDefinitions($original_field_storage_definitions);
     $this->storage->setTableMapping($sandbox['original_table_mapping']);
+
+    // Store the temporary table name mappings for later reuse.
+    $sandbox['temporary_table_names'] = $temporary_table_names;
   }
 
   /**
    * {@inheritdoc}
    */
   protected function postUpdateEntityTypeSchema(EntityTypeInterface $entity_type, EntityTypeInterface $original, array $field_storage_definitions, array $original_field_storage_definitions, array &$sandbox = NULL) {
-    /** @var \Drupal\Core\Entity\Sql\TableMappingInterface $temporary_table_mapping */
-    $temporary_table_mapping = $sandbox['temporary_table_mapping'];
     /** @var \Drupal\Core\Entity\Sql\TableMappingInterface $original_table_mapping */
     $original_table_mapping = $sandbox['original_table_mapping'];
     /** @var \Drupal\Core\Entity\Sql\TableMappingInterface $new_table_mapping */
@@ -522,7 +527,10 @@ class SqlContentEntityStorageSchema implements DynamicallyFieldableEntityStorage
 
     // Rename the original tables so we can put them back in place in case
     // anything goes wrong.
-    $backup_table_names = array_combine($original_table_mapping->getTableNames(), $backup_table_mapping->getTableNames());
+    $backup_table_names = array_combine(
+      $this->getTableNames($original, $original_field_storage_definitions, $original_table_mapping),
+      $this->getTableNames($original, $original_field_storage_definitions, $backup_table_mapping)
+    );
     $renamed_tables = [];
     try {
       foreach ($backup_table_names as $original_table_name => $backup_table_name) {
@@ -542,8 +550,7 @@ class SqlContentEntityStorageSchema implements DynamicallyFieldableEntityStorage
     // Put the new tables in place and update the entity type and field storage
     // definitions.
     try {
-      $table_name_mapping = array_combine($temporary_table_mapping->getTableNames(), $new_table_mapping->getTableNames());
-      foreach ($table_name_mapping as $temp_table_name => $current_table_name) {
+      foreach ($sandbox['temporary_table_names'] as $current_table_name => $temp_table_name) {
         $this->database->schema()->renameTable($temp_table_name, $current_table_name);
       }
 
@@ -603,14 +610,49 @@ class SqlContentEntityStorageSchema implements DynamicallyFieldableEntityStorage
   }
 
   /**
+   * Gets a list of table names for this entity type, field storage and mapping.
+   *
+   * The default table mapping does not return dedicated revision table names
+   * for non-revisionable fields attached to revisionable entity types. Since
+   * both the storage and the storage handlers expect them to be existing, the
+   * missing table names need to be manually restored.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeInterface $entity_type
+   *   An entity type definition.
+   * @param \Drupal\Core\Field\FieldStorageDefinitionInterface[] $field_storage_definitions
+   *   An array of field storage definitions.
+   * @param \Drupal\Core\Entity\Sql\TableMappingInterface $table_mapping
+   *   A table mapping.
+   *
+   * @return string[]
+   *   An array of field table names.
+   *
+   * @todo Remove this once the behavior of the default table mapping, the
+   *    storage handler, and the storage schema handler are reconciled in
+   *    https://www.drupal.org/node/3113639.
+   */
+  private function getTableNames(EntityTypeInterface $entity_type, array $field_storage_definitions, TableMappingInterface $table_mapping) {
+    $table_names = $table_mapping->getTableNames();
+    if ($table_mapping instanceof DefaultTableMapping && $entity_type->isRevisionable()) {
+      foreach ($field_storage_definitions as $storage_definition) {
+        if ($table_mapping->requiresDedicatedTableStorage($storage_definition)) {
+          $dedicated_revision_table_name = $table_mapping->getDedicatedRevisionTableName($storage_definition);
+          if (!$storage_definition->isRevisionable() && !in_array($dedicated_revision_table_name, $table_names)) {
+            $table_names[] = $dedicated_revision_table_name;
+          }
+        }
+      }
+    }
+    return $table_names;
+  }
+
+  /**
    * {@inheritdoc}
    */
   protected function handleEntityTypeSchemaUpdateExceptionOnDataCopy(EntityTypeInterface $entity_type, EntityTypeInterface $original, array &$sandbox) {
     // In case of an error during the save process, we need to clean up the
     // temporary tables.
-    /** @var \Drupal\Core\Entity\Sql\TableMappingInterface $temporary_table_mapping */
-    $temporary_table_mapping = $sandbox['temporary_table_mapping'];
-    foreach ($temporary_table_mapping->getTableNames() as $table_name) {
+    foreach ($sandbox['temporary_table_names'] as $table_name) {
       $this->database->schema()->dropTable($table_name);
     }
   }

--- a/core/lib/Drupal/Core/Entity/entity.api.php
+++ b/core/lib/Drupal/Core/Entity/entity.api.php
@@ -1817,6 +1817,11 @@ function hook_entity_form_display_alter(\Drupal\Core\Entity\Display\EntityFormDi
 /**
  * Provides custom base field definitions for a content entity type.
  *
+ * Field (storage) definitions returned by this hook must run through the
+ * regular field storage life-cycle operations: they need to be properly
+ * installed, updated, and uninstalled. This would typically be done through the
+ * Entity Update API provided by the entity definition update manager.
+ *
  * @param \Drupal\Core\Entity\EntityTypeInterface $entity_type
  *   The entity type definition.
  *
@@ -1828,6 +1833,8 @@ function hook_entity_form_display_alter(\Drupal\Core\Entity\Display\EntityFormDi
  * @see hook_entity_bundle_field_info_alter()
  * @see \Drupal\Core\Field\FieldDefinitionInterface
  * @see \Drupal\Core\Entity\EntityFieldManagerInterface::getFieldDefinitions()
+ * @see \Drupal\Core\Entity\EntityDefinitionUpdateManagerInterface
+ * @see https://www.drupal.org/node/3034742
  */
 function hook_entity_base_field_info(\Drupal\Core\Entity\EntityTypeInterface $entity_type) {
   if ($entity_type->id() == 'node') {
@@ -1932,6 +1939,11 @@ function hook_entity_bundle_field_info_alter(&$fields, \Drupal\Core\Entity\Entit
 /**
  * Provides field storage definitions for a content entity type.
  *
+ * Field storage definitions returned by this hook must run through the regular
+ * field storage life-cycle operations: they need to be properly installed,
+ * updated, and uninstalled. This would typically be done through the Entity
+ * Update API provided by the entity definition update manager.
+ *
  * @param \Drupal\Core\Entity\EntityTypeInterface $entity_type
  *   The entity type definition.
  *
@@ -1969,6 +1981,8 @@ function hook_entity_field_storage_info(\Drupal\Core\Entity\EntityTypeInterface 
  *   The entity type definition.
  *
  * @see hook_entity_field_storage_info()
+ * @see \Drupal\Core\Entity\EntityDefinitionUpdateManagerInterface
+ * @see https://www.drupal.org/node/3034742
  */
 function hook_entity_field_storage_info_alter(&$fields, \Drupal\Core\Entity\EntityTypeInterface $entity_type) {
   // Alter the max_length setting.

--- a/core/lib/Drupal/Core/Extension/ExtensionList.php
+++ b/core/lib/Drupal/Core/Extension/ExtensionList.php
@@ -563,4 +563,21 @@ abstract class ExtensionList {
     return $info;
   }
 
+  /**
+   * Tests the compatibility of an extension.
+   *
+   * @param string $name
+   *   The extension name to check.
+   *
+   * @return bool
+   *   TRUE if the extension is incompatible and FALSE if not.
+   *
+   * @throws \Drupal\Core\Extension\Exception\UnknownExtensionException
+   *   If there is no extension with the supplied name.
+   */
+  public function checkIncompatibility($name) {
+    $extension = $this->get($name);
+    return $extension->info['core_incompatible'] || (isset($extension->info['php']) && version_compare(phpversion(), $extension->info['php']) < 0);
+  }
+
 }

--- a/core/modules/action/action.info.yml
+++ b/core/modules/action/action.info.yml
@@ -6,7 +6,7 @@ package: Core
 core: 8.x
 configure: entity.action.collection
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/action/tests/action_form_ajax_test/action_form_ajax_test.info.yml
+++ b/core/modules/action/tests/action_form_ajax_test/action_form_ajax_test.info.yml
@@ -6,7 +6,7 @@ package: Core
 core: 8.x
 hidden: true
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/aggregator/aggregator.info.yml
+++ b/core/modules/aggregator/aggregator.info.yml
@@ -9,7 +9,7 @@ dependencies:
   - drupal:file
   - drupal:options
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/aggregator/tests/modules/aggregator_test/aggregator_test.info.yml
+++ b/core/modules/aggregator/tests/modules/aggregator_test/aggregator_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/aggregator/tests/modules/aggregator_test_views/aggregator_test_views.info.yml
+++ b/core/modules/aggregator/tests/modules/aggregator_test_views/aggregator_test_views.info.yml
@@ -8,7 +8,7 @@ dependencies:
   - drupal:aggregator
   - drupal:views
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/automated_cron/automated_cron.info.yml
+++ b/core/modules/automated_cron/automated_cron.info.yml
@@ -6,7 +6,7 @@ package: Core
 core: 8.x
 configure: system.cron_settings
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/ban/ban.info.yml
+++ b/core/modules/ban/ban.info.yml
@@ -6,7 +6,7 @@ package: Core
 core: 8.x
 configure: ban.admin_page
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/basic_auth/basic_auth.info.yml
+++ b/core/modules/basic_auth/basic_auth.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:user
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/basic_auth/tests/modules/basic_auth_test/basic_auth_test.info.yml
+++ b/core/modules/basic_auth/tests/modules/basic_auth_test/basic_auth_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/big_pipe/big_pipe.info.yml
+++ b/core/modules/big_pipe/big_pipe.info.yml
@@ -5,7 +5,7 @@ package: Core
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/big_pipe/tests/modules/big_pipe_regression_test/big_pipe_regression_test.info.yml
+++ b/core/modules/big_pipe/tests/modules/big_pipe_regression_test/big_pipe_regression_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/big_pipe/tests/modules/big_pipe_test/big_pipe_test.info.yml
+++ b/core/modules/big_pipe/tests/modules/big_pipe_test/big_pipe_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/big_pipe/tests/themes/big_pipe_test_theme/big_pipe_test_theme.info.yml
+++ b/core/modules/big_pipe/tests/themes/big_pipe_test_theme/big_pipe_test_theme.info.yml
@@ -4,7 +4,7 @@ description: 'Theme for testing BigPipe edge cases.'
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/block/block.info.yml
+++ b/core/modules/block/block.info.yml
@@ -6,7 +6,7 @@ package: Core
 core: 8.x
 configure: block.admin_display
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/block/tests/modules/block_test/block_test.info.yml
+++ b/core/modules/block/tests/modules/block_test/block_test.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:block
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/block/tests/modules/block_test/themes/block_test_specialchars_theme/block_test_specialchars_theme.info.yml
+++ b/core/modules/block/tests/modules/block_test/themes/block_test_specialchars_theme/block_test_specialchars_theme.info.yml
@@ -6,7 +6,7 @@ regions:
   content: Content
   help: Help
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/block/tests/modules/block_test/themes/block_test_theme/block_test_theme.info.yml
+++ b/core/modules/block/tests/modules/block_test/themes/block_test_theme/block_test_theme.info.yml
@@ -15,7 +15,7 @@ regions_hidden:
   - sidebar_first
   - sidebar_second
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/block/tests/modules/block_test_views/block_test_views.info.yml
+++ b/core/modules/block/tests/modules/block_test_views/block_test_views.info.yml
@@ -8,7 +8,7 @@ dependencies:
   - drupal:block
   - drupal:views
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/block_content/block_content.info.yml
+++ b/core/modules/block_content/block_content.info.yml
@@ -10,7 +10,7 @@ dependencies:
   - drupal:user
 configure: entity.block_content.collection
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/block_content/tests/modules/block_content_test/block_content_test.info.yml
+++ b/core/modules/block_content/tests/modules/block_content_test/block_content_test.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:block_content
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/block_content/tests/modules/block_content_test_views/block_content_test_views.info.yml
+++ b/core/modules/block_content/tests/modules/block_content_test_views/block_content_test_views.info.yml
@@ -8,7 +8,7 @@ dependencies:
   - drupal:block_content
   - drupal:views
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/block_place/block_place.info.yml
+++ b/core/modules/block_place/block_place.info.yml
@@ -8,7 +8,7 @@ hidden: true
 dependencies:
   - drupal:block
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/book/book.info.yml
+++ b/core/modules/book/book.info.yml
@@ -8,7 +8,7 @@ dependencies:
   - drupal:node
 configure: book.settings
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/book/tests/modules/book_breadcrumb_test/book_breadcrumb_test.info.yml
+++ b/core/modules/book/tests/modules/book_breadcrumb_test/book_breadcrumb_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/book/tests/modules/book_test/book_test.info.yml
+++ b/core/modules/book/tests/modules/book_test/book_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/book/tests/modules/book_test_views/book_test_views.info.yml
+++ b/core/modules/book/tests/modules/book_test_views/book_test_views.info.yml
@@ -8,7 +8,7 @@ dependencies:
  - drupal:book
  - drupal:views
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/breakpoint/breakpoint.info.yml
+++ b/core/modules/breakpoint/breakpoint.info.yml
@@ -5,7 +5,7 @@ package: Core
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/breakpoint/tests/modules/breakpoint_module_test/breakpoint_module_test.info.yml
+++ b/core/modules/breakpoint/tests/modules/breakpoint_module_test/breakpoint_module_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/breakpoint/tests/themes/breakpoint_theme_test/breakpoint_theme_test.info.yml
+++ b/core/modules/breakpoint/tests/themes/breakpoint_theme_test/breakpoint_theme_test.info.yml
@@ -5,7 +5,7 @@ description: 'Test theme for breakpoint.'
 core: 8.x
 base theme: bartik
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/ckeditor/ckeditor.info.yml
+++ b/core/modules/ckeditor/ckeditor.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:editor
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/ckeditor/tests/modules/ckeditor_test.info.yml
+++ b/core/modules/ckeditor/tests/modules/ckeditor_test.info.yml
@@ -5,7 +5,7 @@ core: 8.x
 package: Testing
 # version: VERSION
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/color/color.info.yml
+++ b/core/modules/color/color.info.yml
@@ -5,7 +5,7 @@ package: Core
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/color/tests/modules/color_test/color_test.info.yml
+++ b/core/modules/color/tests/modules/color_test/color_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/color/tests/modules/color_test/themes/color_test_theme/color_test_theme.info.yml
+++ b/core/modules/color/tests/modules/color_test/themes/color_test_theme/color_test_theme.info.yml
@@ -6,7 +6,7 @@ core: 8.x
 libraries:
   - color_test_theme/base
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/comment/comment.info.yml
+++ b/core/modules/comment/comment.info.yml
@@ -8,7 +8,7 @@ dependencies:
   - drupal:text
 configure: comment.admin
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/comment/tests/modules/comment_empty_title_test/comment_empty_title_test.info.yml
+++ b/core/modules/comment/tests/modules/comment_empty_title_test/comment_empty_title_test.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:comment
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/comment/tests/modules/comment_test/comment_test.info.yml
+++ b/core/modules/comment/tests/modules/comment_test/comment_test.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:comment
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/comment/tests/modules/comment_test_views/comment_test_views.info.yml
+++ b/core/modules/comment/tests/modules/comment_test_views/comment_test_views.info.yml
@@ -8,7 +8,7 @@ dependencies:
   - drupal:comment
   - drupal:views
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/config/config.info.yml
+++ b/core/modules/config/config.info.yml
@@ -6,7 +6,7 @@ package: Core
 core: 8.x
 configure: config.sync
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/config/tests/config_clash_test_theme/config_clash_test_theme.info.yml
+++ b/core/modules/config/tests/config_clash_test_theme/config_clash_test_theme.info.yml
@@ -9,7 +9,7 @@ regions:
   left: Left
   right: Right
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/config/tests/config_collection_clash_install_test/config_collection_clash_install_test.info.yml
+++ b/core/modules/config/tests/config_collection_clash_install_test/config_collection_clash_install_test.info.yml
@@ -8,7 +8,7 @@ core: 8.x
 dependencies:
   - drupal:config_collection_install_test
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/config/tests/config_collection_install_test/config_collection_install_test.info.yml
+++ b/core/modules/config/tests/config_collection_install_test/config_collection_install_test.info.yml
@@ -4,7 +4,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/config/tests/config_entity_static_cache_test/config_entity_static_cache_test.info.yml
+++ b/core/modules/config/tests/config_entity_static_cache_test/config_entity_static_cache_test.info.yml
@@ -4,7 +4,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/config/tests/config_events_test/config_events_test.info.yml
+++ b/core/modules/config/tests/config_events_test/config_events_test.info.yml
@@ -4,7 +4,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/config/tests/config_import_test/config_import_test.info.yml
+++ b/core/modules/config/tests/config_import_test/config_import_test.info.yml
@@ -4,7 +4,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/config/tests/config_install_dependency_test/config_install_dependency_test.info.yml
+++ b/core/modules/config/tests/config_install_dependency_test/config_install_dependency_test.info.yml
@@ -4,7 +4,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/config/tests/config_install_double_dependency_test/config_install_double_dependency_test.info.yml
+++ b/core/modules/config/tests/config_install_double_dependency_test/config_install_double_dependency_test.info.yml
@@ -4,7 +4,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/config/tests/config_install_fail_test/config_install_fail_test.info.yml
+++ b/core/modules/config/tests/config_install_fail_test/config_install_fail_test.info.yml
@@ -6,7 +6,7 @@ core: 8.x
 dependencies:
   - drupal:config_test
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/config/tests/config_integration_test/config_integration_test.info.yml
+++ b/core/modules/config/tests/config_integration_test/config_integration_test.info.yml
@@ -6,7 +6,7 @@ core: 8.x
 dependencies:
   - drupal:config_test
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/config/tests/config_other_module_config_test/config_other_module_config_test.info.yml
+++ b/core/modules/config/tests/config_other_module_config_test/config_other_module_config_test.info.yml
@@ -4,7 +4,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/config/tests/config_override_integration_test/config_override_integration_test.info.yml
+++ b/core/modules/config/tests/config_override_integration_test/config_override_integration_test.info.yml
@@ -8,7 +8,7 @@ dependencies:
   - drupal:block
   - drupal:block_test
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/config/tests/config_override_test/config_override_test.info.yml
+++ b/core/modules/config/tests/config_override_test/config_override_test.info.yml
@@ -8,7 +8,7 @@ dependencies:
   - drupal:block
   - drupal:block_content
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/config/tests/config_schema_test/config_schema_test.info.yml
+++ b/core/modules/config/tests/config_schema_test/config_schema_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 core: 8.x
 hidden: true
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/config/tests/config_test/config_test.info.yml
+++ b/core/modules/config/tests/config_test/config_test.info.yml
@@ -4,7 +4,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/config/tests/config_test_id_mismatch/config_test_id_mismatch.info.yml
+++ b/core/modules/config/tests/config_test_id_mismatch/config_test_id_mismatch.info.yml
@@ -6,7 +6,7 @@ core: 8.x
 dependencies:
   - drupal:config_test
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/config/tests/config_test_language/config_test_language.info.yml
+++ b/core/modules/config/tests/config_test_language/config_test_language.info.yml
@@ -6,7 +6,7 @@ core: 8.x
 dependencies:
   - drupal:config_test
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/config_translation/config_translation.info.yml
+++ b/core/modules/config_translation/config_translation.info.yml
@@ -8,7 +8,7 @@ configure: config_translation.mapper_list
 dependencies:
   - drupal:locale
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/config_translation/tests/modules/config_translation_test/config_translation_test.info.yml
+++ b/core/modules/config_translation/tests/modules/config_translation_test/config_translation_test.info.yml
@@ -8,7 +8,7 @@ dependencies:
   - drupal:config_translation
   - drupal:config_test
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/config_translation/tests/themes/config_translation_test_theme/config_translation_test_theme.info.yml
+++ b/core/modules/config_translation/tests/themes/config_translation_test_theme/config_translation_test_theme.info.yml
@@ -4,7 +4,7 @@ description: 'Theme for testing the configuration translation mapper system'
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/contact/contact.info.yml
+++ b/core/modules/contact/contact.info.yml
@@ -6,7 +6,7 @@ package: Core
 core: 8.x
 configure: entity.contact_form.collection
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/contact/tests/modules/contact_storage_test/contact_storage_test.info.yml
+++ b/core/modules/contact/tests/modules/contact_storage_test/contact_storage_test.info.yml
@@ -8,7 +8,7 @@ dependencies:
   - drupal:contact
   - drupal:user
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/contact/tests/modules/contact_test/contact_test.info.yml
+++ b/core/modules/contact/tests/modules/contact_test/contact_test.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:contact
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/contact/tests/modules/contact_test_views/contact_test_views.info.yml
+++ b/core/modules/contact/tests/modules/contact_test_views/contact_test_views.info.yml
@@ -9,7 +9,7 @@ dependencies:
   - drupal:views
   - drupal:user
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/content_moderation/content_moderation.info.yml
+++ b/core/modules/content_moderation/content_moderation.info.yml
@@ -8,7 +8,7 @@ configure: entity.workflow.collection
 dependencies:
   - drupal:workflows
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/content_moderation/tests/modules/content_moderation_test_local_task/content_moderation_test_local_task.info.yml
+++ b/core/modules/content_moderation/tests/modules/content_moderation_test_local_task/content_moderation_test_local_task.info.yml
@@ -8,7 +8,7 @@ dependencies:
   - drupal:content_moderation
   - drupal:node
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/content_moderation/tests/modules/content_moderation_test_views/content_moderation_test_views.info.yml
+++ b/core/modules/content_moderation/tests/modules/content_moderation_test_views/content_moderation_test_views.info.yml
@@ -10,7 +10,7 @@ dependencies:
   - drupal:views
   - drupal:entity_test
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/content_translation/content_translation.info.yml
+++ b/core/modules/content_translation/content_translation.info.yml
@@ -8,7 +8,7 @@ package: Multilingual
 core: 8.x
 configure: language.content_settings_page
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/content_translation/tests/modules/content_translation_test/content_translation_test.info.yml
+++ b/core/modules/content_translation/tests/modules/content_translation_test/content_translation_test.info.yml
@@ -9,7 +9,7 @@ dependencies:
   - drupal:language
   - drupal:entity_test
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/content_translation/tests/modules/content_translation_test_views/content_translation_test_views.info.yml
+++ b/core/modules/content_translation/tests/modules/content_translation_test_views/content_translation_test_views.info.yml
@@ -8,7 +8,7 @@ dependencies:
   - drupal:content_translation
   - drupal:views
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/contextual/contextual.info.yml
+++ b/core/modules/contextual/contextual.info.yml
@@ -5,7 +5,7 @@ package: Core
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/contextual/tests/modules/contextual_test/contextual_test.info.yml
+++ b/core/modules/contextual/tests/modules/contextual_test/contextual_test.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:contextual
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/datetime/datetime.info.yml
+++ b/core/modules/datetime/datetime.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:field
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/datetime/tests/modules/datetime_test/datetime_test.info.yml
+++ b/core/modules/datetime/tests/modules/datetime_test/datetime_test.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:views
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/datetime_range/datetime_range.info.yml
+++ b/core/modules/datetime_range/datetime_range.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:datetime
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/datetime_range/tests/modules/datetime_range_test/datetime_range_test.info.yml
+++ b/core/modules/datetime_range/tests/modules/datetime_range_test/datetime_range_test.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:taxonomy
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/dblog/dblog.info.yml
+++ b/core/modules/dblog/dblog.info.yml
@@ -6,7 +6,7 @@ package: Core
 core: 8.x
 configure: system.logging_settings
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/dblog/tests/modules/dblog_test_views/dblog_test_views.info.yml
+++ b/core/modules/dblog/tests/modules/dblog_test_views/dblog_test_views.info.yml
@@ -8,7 +8,7 @@ dependencies:
   - drupal:dblog
   - drupal:views
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/dynamic_page_cache/dynamic_page_cache.info.yml
+++ b/core/modules/dynamic_page_cache/dynamic_page_cache.info.yml
@@ -5,7 +5,7 @@ package: Core
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/dynamic_page_cache/tests/dynamic_page_cache_test/dynamic_page_cache_test.info.yml
+++ b/core/modules/dynamic_page_cache/tests/dynamic_page_cache_test/dynamic_page_cache_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/editor/editor.info.yml
+++ b/core/modules/editor/editor.info.yml
@@ -9,7 +9,7 @@ dependencies:
   - drupal:file
 configure: filter.admin_overview
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/editor/tests/editor_private_test/editor_private_test.info.yml
+++ b/core/modules/editor/tests/editor_private_test/editor_private_test.info.yml
@@ -8,7 +8,7 @@ dependencies:
   - drupal:filter
   - drupal:ckeditor
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/editor/tests/modules/editor_test.info.yml
+++ b/core/modules/editor/tests/modules/editor_test.info.yml
@@ -5,7 +5,7 @@ core: 8.x
 package: Testing
 # version: VERSION
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/entity_reference/entity_reference.info.yml
+++ b/core/modules/entity_reference/entity_reference.info.yml
@@ -6,7 +6,7 @@ package: Field types
 core: 8.x
 hidden: true
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/field/field.info.yml
+++ b/core/modules/field/field.info.yml
@@ -5,7 +5,7 @@ package: Core
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/field/tests/modules/field_plugins_test/field_plugins_test.info.yml
+++ b/core/modules/field/tests/modules/field_plugins_test/field_plugins_test.info.yml
@@ -7,7 +7,7 @@ package: Testing
 dependencies:
   - drupal:text
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/field/tests/modules/field_test/field_test.info.yml
+++ b/core/modules/field/tests/modules/field_test/field_test.info.yml
@@ -7,7 +7,7 @@ package: Testing
 dependencies:
   - drupal:entity_test
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/field/tests/modules/field_test_boolean_access_denied/field_test_boolean_access_denied.info.yml
+++ b/core/modules/field/tests/modules/field_test_boolean_access_denied/field_test_boolean_access_denied.info.yml
@@ -7,7 +7,7 @@ package: Testing
 dependencies:
   - drupal:field
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/field/tests/modules/field_test_config/field_test_config.info.yml
+++ b/core/modules/field/tests/modules/field_test_config/field_test_config.info.yml
@@ -5,7 +5,7 @@ core: 8.x
 package: Testing
 # version: VERSION
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/field/tests/modules/field_test_views/field_test_views.info.yml
+++ b/core/modules/field/tests/modules/field_test_views/field_test_views.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:views
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/field/tests/modules/field_third_party_test/field_third_party_test.info.yml
+++ b/core/modules/field/tests/modules/field_third_party_test/field_third_party_test.info.yml
@@ -8,7 +8,7 @@ dependencies:
   - drupal:entity_test
   - drupal:field_test
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/field/tests/modules/field_timestamp_test/field_timestamp_test.info.yml
+++ b/core/modules/field/tests/modules/field_timestamp_test/field_timestamp_test.info.yml
@@ -8,7 +8,7 @@ dependencies:
   - drupal:entity_test
   - drupal:field
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/field_layout/field_layout.info.yml
+++ b/core/modules/field_layout/field_layout.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:layout_discovery
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/field_layout/tests/modules/field_layout_test/field_layout_test.info.yml
+++ b/core/modules/field_layout/tests/modules/field_layout_test/field_layout_test.info.yml
@@ -7,7 +7,7 @@ package: Testing
 dependencies:
   - drupal:entity_test
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/field_ui/field_ui.info.yml
+++ b/core/modules/field_ui/field_ui.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:field
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/field_ui/tests/modules/field_ui_test/field_ui_test.info.yml
+++ b/core/modules/field_ui/tests/modules/field_ui_test/field_ui_test.info.yml
@@ -5,7 +5,7 @@ core: 8.x
 package: Testing
 # version: VERSION
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/file/file.info.yml
+++ b/core/modules/file/file.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:field
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/file/tests/file_module_test/file_module_test.info.yml
+++ b/core/modules/file/tests/file_module_test/file_module_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/file/tests/file_test/file_test.info.yml
+++ b/core/modules/file/tests/file_test/file_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/file/tests/modules/file_test_views/file_test_views.info.yml
+++ b/core/modules/file/tests/modules/file_test_views/file_test_views.info.yml
@@ -8,7 +8,7 @@ dependencies:
   - drupal:file
   - drupal:views
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/filter/filter.info.yml
+++ b/core/modules/filter/filter.info.yml
@@ -8,7 +8,7 @@ configure: filter.admin_overview
 dependencies:
   - drupal:user
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/filter/tests/filter_test/filter_test.info.yml
+++ b/core/modules/filter/tests/filter_test/filter_test.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:filter
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/filter/tests/filter_test_plugin/filter_test_plugin.info.yml
+++ b/core/modules/filter/tests/filter_test_plugin/filter_test_plugin.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/forum/forum.info.yml
+++ b/core/modules/forum/forum.info.yml
@@ -12,7 +12,7 @@ package: Core
 core: 8.x
 configure: forum.overview
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/forum/tests/modules/forum_test_views/forum_test_views.info.yml
+++ b/core/modules/forum/tests/modules/forum_test_views/forum_test_views.info.yml
@@ -8,7 +8,7 @@ dependencies:
   - drupal:forum
   - drupal:views
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/hal/hal.info.yml
+++ b/core/modules/hal/hal.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:serialization
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/hal/tests/modules/hal_test/hal_test.info.yml
+++ b/core/modules/hal/tests/modules/hal_test/hal_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/help/help.info.yml
+++ b/core/modules/help/help.info.yml
@@ -5,7 +5,7 @@ package: Core
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/help/tests/modules/help_page_test/help_page_test.info.yml
+++ b/core/modules/help/tests/modules/help_page_test/help_page_test.info.yml
@@ -6,7 +6,7 @@ package: Testing
 core: 8.x
 hidden: true
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/help/tests/modules/help_test/help_test.info.yml
+++ b/core/modules/help/tests/modules/help_test/help_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 dependencies:
   - drupal:help
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/help/tests/modules/more_help_page_test/more_help_page_test.info.yml
+++ b/core/modules/help/tests/modules/more_help_page_test/more_help_page_test.info.yml
@@ -6,7 +6,7 @@ package: Testing
 core: 8.x
 hidden: true
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/history/history.info.yml
+++ b/core/modules/history/history.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:node
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/image/image.info.yml
+++ b/core/modules/image/image.info.yml
@@ -8,7 +8,7 @@ dependencies:
   - drupal:file
 configure: entity.image_style.collection
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/image/tests/modules/image_access_test_hidden/image_access_test_hidden.info.yml
+++ b/core/modules/image/tests/modules/image_access_test_hidden/image_access_test_hidden.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/image/tests/modules/image_module_test/image_module_test.info.yml
+++ b/core/modules/image/tests/modules/image_module_test/image_module_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/image/tests/modules/image_test_views/image_test_views.info.yml
+++ b/core/modules/image/tests/modules/image_test_views/image_test_views.info.yml
@@ -8,7 +8,7 @@ dependencies:
   - drupal:image
   - drupal:views
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/inline_form_errors/inline_form_errors.info.yml
+++ b/core/modules/inline_form_errors/inline_form_errors.info.yml
@@ -5,7 +5,7 @@ description: 'Places error messages adjacent to form inputs, for improved usabil
 core: 8.x
 package: Core
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/jsonapi/jsonapi.info.yml
+++ b/core/modules/jsonapi/jsonapi.info.yml
@@ -7,7 +7,7 @@ configure: jsonapi.settings
 dependencies:
   - drupal:serialization
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/jsonapi/tests/modules/jsonapi_test_collection_count/jsonapi_test_collection_count.info.yml
+++ b/core/modules/jsonapi/tests/modules/jsonapi_test_collection_count/jsonapi_test_collection_count.info.yml
@@ -3,7 +3,7 @@ type: module
 package: Testing
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/jsonapi/tests/modules/jsonapi_test_data_type/jsonapi_test_data_type.info.yml
+++ b/core/modules/jsonapi/tests/modules/jsonapi_test_data_type/jsonapi_test_data_type.info.yml
@@ -3,7 +3,7 @@ type: module
 package: Testing
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/jsonapi/tests/modules/jsonapi_test_field_access/jsonapi_test_field_access.info.yml
+++ b/core/modules/jsonapi/tests/modules/jsonapi_test_field_access/jsonapi_test_field_access.info.yml
@@ -4,7 +4,7 @@ description: 'Provides a custom field access hook to test JSON API field access 
 package: Testing
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/jsonapi/tests/modules/jsonapi_test_field_aliasing/jsonapi_test_field_aliasing.info.yml
+++ b/core/modules/jsonapi/tests/modules/jsonapi_test_field_aliasing/jsonapi_test_field_aliasing.info.yml
@@ -3,7 +3,7 @@ type: module
 package: Testing
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/jsonapi/tests/modules/jsonapi_test_field_filter_access/jsonapi_test_field_filter_access.info.yml
+++ b/core/modules/jsonapi/tests/modules/jsonapi_test_field_filter_access/jsonapi_test_field_filter_access.info.yml
@@ -4,7 +4,7 @@ description: 'Provides custom access related code to test JSON:API filter securi
 package: Testing
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/jsonapi/tests/modules/jsonapi_test_field_type/jsonapi_test_field_type.info.yml
+++ b/core/modules/jsonapi/tests/modules/jsonapi_test_field_type/jsonapi_test_field_type.info.yml
@@ -3,7 +3,7 @@ type: module
 package: Testing
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/jsonapi/tests/modules/jsonapi_test_normalizers_kernel/jsonapi_test_normalizers_kernel.info.yml
+++ b/core/modules/jsonapi/tests/modules/jsonapi_test_normalizers_kernel/jsonapi_test_normalizers_kernel.info.yml
@@ -3,7 +3,7 @@ type: module
 package: Testing
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/language/language.info.yml
+++ b/core/modules/language/language.info.yml
@@ -6,7 +6,7 @@ package: Multilingual
 core: 8.x
 configure: entity.configurable_language.collection
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/language/tests/language_config_override_test/language_config_override_test.info.yml
+++ b/core/modules/language/tests/language_config_override_test/language_config_override_test.info.yml
@@ -5,7 +5,7 @@ core: 8.x
 package: Testing
 # version: VERSION
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/language/tests/language_elements_test/language_elements_test.info.yml
+++ b/core/modules/language/tests/language_elements_test/language_elements_test.info.yml
@@ -7,7 +7,7 @@ package: Testing
 dependencies:
   - drupal:entity_test
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/language/tests/language_entity_field_access_test/language_entity_field_access_test.info.yml
+++ b/core/modules/language/tests/language_entity_field_access_test/language_entity_field_access_test.info.yml
@@ -11,7 +11,7 @@ dependencies:
   - drupal:filter
   - drupal:language
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/language/tests/language_test/language_test.info.yml
+++ b/core/modules/language/tests/language_test/language_test.info.yml
@@ -5,7 +5,7 @@ core: 8.x
 package: Testing
 # version: VERSION
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/language/tests/test_module/test_module.info.yml
+++ b/core/modules/language/tests/test_module/test_module.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/layout_builder/layout_builder.info.yml
+++ b/core/modules/layout_builder/layout_builder.info.yml
@@ -12,7 +12,7 @@ dependencies:
   # @todo Discuss removing in https://www.drupal.org/project/drupal/issues/3003610.
   - drupal:block
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/layout_builder/tests/modules/layout_builder_defaults_test/layout_builder_defaults_test.info.yml
+++ b/core/modules/layout_builder/tests/modules/layout_builder_defaults_test/layout_builder_defaults_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/layout_builder/tests/modules/layout_builder_fieldblock_test/layout_builder_fieldblock_test.info.yml
+++ b/core/modules/layout_builder/tests/modules/layout_builder_fieldblock_test/layout_builder_fieldblock_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/layout_builder/tests/modules/layout_builder_overrides_test/layout_builder_overrides_test.info.yml
+++ b/core/modules/layout_builder/tests/modules/layout_builder_overrides_test/layout_builder_overrides_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/layout_builder/tests/modules/layout_builder_test/layout_builder_test.info.yml
+++ b/core/modules/layout_builder/tests/modules/layout_builder_test/layout_builder_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/layout_builder/tests/modules/layout_builder_views_test/layout_builder_views_test.info.yml
+++ b/core/modules/layout_builder/tests/modules/layout_builder_views_test/layout_builder_views_test.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - views
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/layout_discovery/layout_discovery.info.yml
+++ b/core/modules/layout_discovery/layout_discovery.info.yml
@@ -5,7 +5,7 @@ package: Core
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/layout_discovery/tests/themes/test_layout_theme/test_layout_theme.info.yml
+++ b/core/modules/layout_discovery/tests/themes/test_layout_theme/test_layout_theme.info.yml
@@ -5,7 +5,7 @@ description: 'Theme for testing a theme-provided layout'
 base theme: classy
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/link/link.info.yml
+++ b/core/modules/link/link.info.yml
@@ -7,7 +7,7 @@ package: Field types
 dependencies:
   - drupal:field
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/link/tests/modules/link_test_base_field/link_test_base_field.info.yml
+++ b/core/modules/link/tests/modules/link_test_base_field/link_test_base_field.info.yml
@@ -7,7 +7,7 @@ dependencies:
   - drupal:link
   - drupal:entity_test
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/link/tests/modules/link_test_views/link_test_views.info.yml
+++ b/core/modules/link/tests/modules/link_test_views/link_test_views.info.yml
@@ -9,7 +9,7 @@ dependencies:
   - drupal:views
   - drupal:link
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/locale/locale.info.yml
+++ b/core/modules/locale/locale.info.yml
@@ -9,7 +9,7 @@ dependencies:
   - drupal:language
   - drupal:file
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/locale/tests/modules/early_translation_test/early_translation_test.info.yml
+++ b/core/modules/locale/tests/modules/early_translation_test/early_translation_test.info.yml
@@ -5,7 +5,7 @@ core: 8.x
 package: Testing
 # version: VERSION
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/locale/tests/modules/locale_test/locale_test.info.yml
+++ b/core/modules/locale/tests/modules/locale_test/locale_test.info.yml
@@ -8,7 +8,7 @@ hidden: true
 'interface translation project': locale_test
 'interface translation server pattern': core/modules/locale/test/test.%language.po
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/locale/tests/modules/locale_test_development_release/locale_test_development_release.info.yml
+++ b/core/modules/locale/tests/modules/locale_test_development_release/locale_test_development_release.info.yml
@@ -6,7 +6,7 @@ package: Testing
 core: 8.x
 hidden: true
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/locale/tests/modules/locale_test_translate/locale_test_translate.info.yml
+++ b/core/modules/locale/tests/modules/locale_test_translate/locale_test_translate.info.yml
@@ -8,7 +8,7 @@ hidden: true
 'interface translation project': locale_test_translate
 'interface translation server pattern': core/modules/locale/tests/test.%language.po
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/media/media.info.yml
+++ b/core/modules/media/media.info.yml
@@ -10,7 +10,7 @@ dependencies:
   - drupal:user
 configure: media.settings
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/media/tests/modules/media_test_oembed/media_test_oembed.info.yml
+++ b/core/modules/media/tests/modules/media_test_oembed/media_test_oembed.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:media
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/media/tests/modules/media_test_source/media_test_source.info.yml
+++ b/core/modules/media/tests/modules/media_test_source/media_test_source.info.yml
@@ -5,7 +5,7 @@ core: 8.x
 package: Testing
 # version: VERSION
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/media/tests/modules/media_test_type/media_test_type.info.yml
+++ b/core/modules/media/tests/modules/media_test_type/media_test_type.info.yml
@@ -8,7 +8,7 @@ dependencies:
   - drupal:media
   - drupal:media_test_source
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/media/tests/modules/media_test_views/media_test_views.info.yml
+++ b/core/modules/media/tests/modules/media_test_views/media_test_views.info.yml
@@ -8,7 +8,7 @@ dependencies:
   - drupal:media
   - drupal:views
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/media_library/media_library.info.yml
+++ b/core/modules/media_library/media_library.info.yml
@@ -9,7 +9,7 @@ dependencies:
   - drupal:views
   - drupal:user
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/media_library/tests/modules/media_library_test/media_library_test.info.yml
+++ b/core/modules/media_library/tests/modules/media_library_test/media_library_test.info.yml
@@ -11,7 +11,7 @@ dependencies:
   - drupal:node
   - drupal:path
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/menu_link_content/menu_link_content.info.yml
+++ b/core/modules/menu_link_content/menu_link_content.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:link
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/menu_link_content/menu_link_content.install
+++ b/core/modules/menu_link_content/menu_link_content.install
@@ -6,6 +6,40 @@
  */
 
 /**
+ * Implements hook_requirements().
+ */
+function menu_link_content_requirements($phase) {
+  $requirements = [];
+
+  if ($phase === 'update') {
+    // Check for invalid data before making links revisionable.
+    /** @var \Drupal\Core\Update\UpdateRegistry $registry */
+    $registry = \Drupal::service('update.post_update_registry');
+    $update_name = 'menu_link_content_post_update_make_menu_link_content_revisionable';
+    if (in_array($update_name, $registry->getPendingUpdateFunctions(), TRUE)) {
+      // The 'enabled' field is non-NULL - if we get a NULL value that indicates
+      // a failure to join on menu_link_content_data.
+      $is_broken = \Drupal::entityQuery('menu_link_content')
+        ->condition('enabled', NULL, 'IS NULL')
+        ->range(0, 1)
+        ->accessCheck(FALSE)
+        ->execute();
+      if ($is_broken) {
+        $requirements[$update_name] = [
+          'title' => t('Menu link content data'),
+          'value' => t('Integrity issues detected'),
+          'description' => t('The make_menu_link_content_revisionable database update cannot be run until the data has been fixed. See the <a href=":change_record">change record</a> for more information.', [
+            ':change_record' => 'https://www.drupal.org/node/3117753',
+          ]),
+          'severity' => REQUIREMENT_ERROR,
+        ];
+      }
+    }
+  }
+  return $requirements;
+}
+
+/**
  * Implements hook_install().
  */
 function menu_link_content_install() {

--- a/core/modules/menu_link_content/menu_link_content.post_update.php
+++ b/core/modules/menu_link_content/menu_link_content.post_update.php
@@ -6,12 +6,23 @@
  */
 
 use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\Logger\RfcLogLevel;
+use Drupal\Core\Site\Settings;
+use Drupal\Core\StringTranslation\PluralTranslatableMarkup;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\Url;
+use Drupal\menu_link_content\MenuLinkContentStorage;
 
 /**
  * Update custom menu links to be revisionable.
  */
 function menu_link_content_post_update_make_menu_link_content_revisionable(&$sandbox) {
+  $finished = _menu_link_content_post_update_make_menu_link_content_revisionable__fix_default_langcode($sandbox);
+  if (!$finished) {
+    $sandbox['#finished'] = 0;
+    return NULL;
+  }
+
   $definition_update_manager = \Drupal::entityDefinitionUpdateManager();
   /** @var \Drupal\Core\Entity\EntityLastInstalledSchemaRepositoryInterface $last_installed_schema_repository */
   $last_installed_schema_repository = \Drupal::service('entity.last_installed_schema.repository');
@@ -99,5 +110,104 @@ function menu_link_content_post_update_make_menu_link_content_revisionable(&$san
 
   $definition_update_manager->updateFieldableEntityType($entity_type, $field_storage_definitions, $sandbox);
 
-  return t('Custom menu links have been converted to be revisionable.');
+  if (!empty($sandbox['data_fix']['default_langcode']['processed'])) {
+    $count = $sandbox['data_fix']['default_langcode']['processed'];
+    if (\Drupal::moduleHandler()->moduleExists('dblog')) {
+      // @todo Simplify with https://www.drupal.org/node/2548095
+      $base_url = str_replace('/update.php', '', \Drupal::request()->getBaseUrl());
+      $args = [
+        ':url' => Url::fromRoute('dblog.overview', [], ['query' => ['type' => ['update'], 'severity' => [RfcLogLevel::WARNING]]])
+          ->setOption('base_url', $base_url)
+          ->toString(TRUE)
+          ->getGeneratedUrl(),
+      ];
+      return new PluralTranslatableMarkup($count, 'Custom menu links have been converted to be revisionable. One menu link with data integrity issues was restored. More details have been <a href=":url">logged</a>.', 'Custom menu links have been converted to be revisionable. @count menu links with data integrity issues were restored. More details have been <a href=":url">logged</a>.', $args);
+    }
+    else {
+      return new PluralTranslatableMarkup($count, 'Custom menu links have been converted to be revisionable. One menu link with data integrity issues was restored. More details have been logged.', 'Custom menu links have been converted to be revisionable. @count menu links with data integrity issues were restored. More details have been logged.');
+    }
+  }
+  else {
+    return t('Custom menu links have been converted to be revisionable.');
+  }
+}
+
+/**
+ * Fixes recoverable data integrity issues in the "default_langcode" field.
+ *
+ * @param array $sandbox
+ *   The update sandbox array.
+ *
+ * @return bool
+ *   TRUE if the operation was finished, FALSE otherwise.
+ *
+ * @internal
+ */
+function _menu_link_content_post_update_make_menu_link_content_revisionable__fix_default_langcode(array &$sandbox) {
+  if (!empty($sandbox['data_fix']['default_langcode']['finished'])) {
+    return TRUE;
+  }
+
+  $storage = \Drupal::entityTypeManager()->getStorage('menu_link_content');
+  if (!$storage instanceof MenuLinkContentStorage) {
+    return TRUE;
+  }
+  elseif (!isset($sandbox['data_fix']['default_langcode']['last_id'])) {
+    $sandbox['data_fix']['default_langcode'] = [
+      'last_id' => 0,
+      'processed' => 0,
+    ];
+  }
+
+  $database = \Drupal::database();
+  $data_table_name = 'menu_link_content_data';
+  $last_id = $sandbox['data_fix']['default_langcode']['last_id'];
+  $limit = Settings::get('update_sql_batch_size', 200);
+
+  // Detect records in the data table matching the base table language, but
+  // having the "default_langcode" flag set to with 0, which is not supported.
+  $query = $database->select($data_table_name, 'd');
+  $query->leftJoin('menu_link_content', 'b', 'd.id = b.id AND d.langcode = b.langcode AND d.default_langcode = 0');
+  $result = $query->fields('d', ['id', 'langcode'])
+    ->condition('d.id', $last_id, '>')
+    ->isNotNull('b.id')
+    ->orderBy('d.id')
+    ->range(0, $limit)
+    ->execute();
+
+  foreach ($result as $record) {
+    $sandbox['data_fix']['default_langcode']['last_id'] = $record->id;
+
+    // We need to exclude any menu link already having also a data table record
+    // with the "default_langcode" flag set to 1, because this is a data
+    // integrity issue that cannot be fixed automatically. However the latter
+    // will not make the update fail.
+    $has_default_langcode = (bool) $database->select($data_table_name, 'd')
+      ->fields('d', ['id'])
+      ->condition('d.id', $record->id)
+      ->condition('d.default_langcode', 1)
+      ->range(0, 1)
+      ->execute()
+      ->fetchField();
+
+    if ($has_default_langcode) {
+      continue;
+    }
+
+    $database->update($data_table_name)
+      ->fields(['default_langcode' => 1])
+      ->condition('id', $record->id)
+      ->condition('langcode', $record->langcode)
+      ->execute();
+
+    $sandbox['data_fix']['default_langcode']['processed']++;
+
+    \Drupal::logger('update')
+      ->warning('The menu link with ID @id had data integrity issues and was restored.', ['@id' => $record->id]);
+  }
+
+  $finished = $sandbox['data_fix']['default_langcode']['last_id'] === $last_id;
+  $sandbox['data_fix']['default_langcode']['finished'] = $finished;
+
+  return $finished;
 }

--- a/core/modules/menu_link_content/tests/fixtures/update/drupal-8.menu-link-content-null-data-3056543.php
+++ b/core/modules/menu_link_content/tests/fixtures/update/drupal-8.menu-link-content-null-data-3056543.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * @file
+ * Contains database additions to drupal-8.filled.standard.php.gz for testing
+ * the upgrade path of https://www.drupal.org/project/drupal/issues/3056543.
+ */
+
+use Drupal\Core\Database\Database;
+
+$connection = Database::getConnection();
+
+$connection->insert('menu_link_content')
+  ->fields([
+    'id' => 997,
+    'bundle' => 'menu_link_content',
+    'uuid' => 'ea32f399-b53b-416c-81a9-e66204236c97',
+    'langcode' => 'en',
+  ])
+  ->execute();
+$connection->insert('menu_link_content_data')
+  ->fields([
+    'id' => 997,
+    'bundle' => 'menu_link_content',
+    'langcode' => 'en',
+    'enabled' => 1,
+    'title' => 'menu_link_997',
+    'menu_name' => 'test-menu',
+    'link__uri' => 'https://drupal.org',
+    'link__title' => '',
+    'link__options' => 'a:0:{}',
+    'external' => 0,
+    'rediscover' => 0,
+    'weight' => 0,
+    'expanded' => 0,
+    'changed' => 1579555997,
+    'default_langcode' => 0,
+  ])
+  ->execute();
+
+$connection->insert('menu_link_content')
+  ->fields([
+    'id' => 998,
+    'bundle' => 'menu_link_content',
+    'uuid' => 'ea32f399-b53b-416c-81a9-e66204236c98',
+    'langcode' => 'en',
+  ])
+  ->execute();
+$connection->insert('menu_link_content_data')
+  ->fields([
+    'id' => 998,
+    'bundle' => 'menu_link_content',
+    'langcode' => 'en',
+    'enabled' => 1,
+    'title' => 'menu_link_998',
+    'menu_name' => 'test-menu',
+    'link__uri' => 'https://drupal.org',
+    'link__title' => '',
+    'link__options' => 'a:0:{}',
+    'external' => 0,
+    'rediscover' => 0,
+    'weight' => 0,
+    'expanded' => 0,
+    'changed' => 1579555997,
+    'default_langcode' => 0,
+  ])
+  ->execute();
+
+$connection->insert('menu_link_content')
+  ->fields([
+    'id' => 999,
+    'bundle' => 'menu_link_content',
+    'uuid' => 'ea32f399-b53b-416c-81a9-e66204236c99',
+    'langcode' => 'en',
+  ])
+  ->execute();
+$connection->insert('menu_link_content_data')
+  ->fields([
+    'id' => 999,
+    'bundle' => 'menu_link_content',
+    'langcode' => 'en',
+    'enabled' => 1,
+    'title' => 'menu_link_999',
+    'menu_name' => 'test-menu',
+    'link__uri' => 'https://drupal.org',
+    'link__title' => '',
+    'link__options' => 'a:0:{}',
+    'external' => 0,
+    'rediscover' => 0,
+    'weight' => 0,
+    'expanded' => 0,
+    'changed' => 1579555997,
+    'default_langcode' => 0,
+  ])
+  ->execute();
+$connection->insert('menu_link_content_data')
+  ->fields([
+    'id' => 999,
+    'bundle' => 'menu_link_content',
+    'langcode' => 'es',
+    'enabled' => 1,
+    'title' => 'menu_link_999-es',
+    'menu_name' => 'test-menu',
+    'link__uri' => 'https://drupal.org',
+    'link__title' => '',
+    'link__options' => 'a:0:{}',
+    'external' => 0,
+    'rediscover' => 0,
+    'weight' => 0,
+    'expanded' => 0,
+    'changed' => 1579555997,
+    'default_langcode' => 1,
+  ])
+  ->execute();

--- a/core/modules/menu_link_content/tests/menu_link_content_dynamic_route/menu_link_content_dynamic_route.info.yml
+++ b/core/modules/menu_link_content/tests/menu_link_content_dynamic_route/menu_link_content_dynamic_route.info.yml
@@ -5,7 +5,7 @@ hidden: true
 dependencies:
   - drupal:menu_link_content
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/menu_link_content/tests/outbound_processing_test/outbound_processing_test.info.yml
+++ b/core/modules/menu_link_content/tests/outbound_processing_test/outbound_processing_test.info.yml
@@ -3,7 +3,7 @@ type: module
 core: 8.x
 hidden: true
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/menu_link_content/tests/src/Functional/Update/MenuLinkContentUpdateTest.php
+++ b/core/modules/menu_link_content/tests/src/Functional/Update/MenuLinkContentUpdateTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\menu_link_content\Functional\Update;
 
+use Drupal\Core\Database\Database;
 use Drupal\FunctionalTests\Update\UpdatePathTestBase;
 use Drupal\user\Entity\User;
 
@@ -20,6 +21,7 @@ class MenuLinkContentUpdateTest extends UpdatePathTestBase {
   protected function setDatabaseDumpFiles() {
     $this->databaseDumpFiles = [
       __DIR__ . '/../../../../../system/tests/fixtures/update/drupal-8.filled.standard.php.gz',
+      __DIR__ . '/../../../fixtures/update/drupal-8.menu-link-content-null-data-3056543.php',
     ];
   }
 
@@ -68,7 +70,25 @@ class MenuLinkContentUpdateTest extends UpdatePathTestBase {
     $entity_type = \Drupal::entityDefinitionUpdateManager()->getEntityType('menu_link_content');
     $this->assertFalse($entity_type->isRevisionable());
 
+    // Set the batch size to 1 to test multiple steps.
+    drupal_rewrite_settings([
+      'settings' => [
+        'update_sql_batch_size' => (object) [
+          'value' => 1,
+          'required' => TRUE,
+        ],
+      ],
+    ]);
+
+    // Check that there are broken menu links in the database tables, initially.
+    $this->assertMenuLinkTitle(997, '');
+    $this->assertMenuLinkTitle(998, '');
+    $this->assertMenuLinkTitle(999, 'menu_link_999-es');
+
     $this->runUpdates();
+
+    // Check that the update function returned the expected message.
+    $this->assertSession()->pageTextContains('Custom menu links have been converted to be revisionable. 2 menu links with data integrity issues were restored. More details have been logged.');
 
     $entity_type = \Drupal::entityDefinitionUpdateManager()->getEntityType('menu_link_content');
     $this->assertTrue($entity_type->isRevisionable());
@@ -100,6 +120,65 @@ class MenuLinkContentUpdateTest extends UpdatePathTestBase {
     $this->assertEquals('Pineapple', $menu_link->label());
     $this->assertEquals('route:user.page', $menu_link->link->uri);
     $this->assertTrue($menu_link->isPublished());
+
+    // Check that two menu links were restored and one was ignored. The latter
+    // cannot be manually restored, since we would end up with two data table
+    // records having "default_langcode" equalling 1, which would not make
+    // sense.
+    $this->assertMenuLinkTitle(997, 'menu_link_997');
+    $this->assertMenuLinkTitle(998, 'menu_link_998');
+    $this->assertMenuLinkTitle(999, 'menu_link_999-es');
+  }
+
+  /**
+   * Assert that a menu link label matches the expectation.
+   *
+   * @param string $id
+   *   The menu link ID.
+   * @param string $expected_title
+   *   The expected menu link title.
+   */
+  protected function assertMenuLinkTitle($id, $expected_title) {
+    $database = \Drupal::database();
+    $query = $database->select('menu_link_content_data', 'd');
+    $query->join('menu_link_content', 'b', 'b.id = d.id AND d.default_langcode = 1');
+    $title = $query
+      ->fields('d', ['title'])
+      ->condition('d.id', $id)
+      ->execute()
+      ->fetchField();
+
+    $this->assertSame($expected_title, $title ?: '');
+  }
+
+  /**
+   * Test the update hook requirements check for revisionable menu links.
+   *
+   * @see menu_link_content_post_update_make_menu_link_content_revisionable()
+   * @see menu_link_content_requirements()
+   */
+  public function testMissingDataUpdateRequirementsCheck() {
+    // Insert invalid data for a non-existent menu link.
+    Database::getConnection()->insert('menu_link_content')
+      ->fields([
+        'id' => '3',
+        'bundle' => 'menu_link_content',
+        'uuid' => '15396f85-3c11-4f52-81af-44d2cb5e829f',
+        'langcode' => 'en',
+      ])
+      ->execute();
+    $this->writeSettings([
+      'settings' => [
+        'update_free_access' => (object) [
+          'value' => TRUE,
+          'required' => TRUE,
+        ],
+      ],
+    ]);
+    $this->drupalGet($this->updateUrl);
+
+    $this->assertSession()->pageTextContains('Errors found');
+    $this->assertSession()->elementTextContains('css', '.system-status-report__entry--error', 'The make_menu_link_content_revisionable database update cannot be run until the data has been fixed.');
   }
 
   /**

--- a/core/modules/menu_ui/menu_ui.info.yml
+++ b/core/modules/menu_ui/menu_ui.info.yml
@@ -8,7 +8,7 @@ configure: entity.menu.collection
 dependencies:
   - drupal:menu_link_content
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/migrate/migrate.info.yml
+++ b/core/modules/migrate/migrate.info.yml
@@ -5,7 +5,7 @@ package: Migration
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/migrate/tests/modules/migrate_entity_test/migrate_entity_test.info.yml
+++ b/core/modules/migrate/tests/modules/migrate_entity_test/migrate_entity_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/migrate/tests/modules/migrate_events_test/migrate_events_test.info.yml
+++ b/core/modules/migrate/tests/modules/migrate_events_test/migrate_events_test.info.yml
@@ -4,7 +4,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/migrate/tests/modules/migrate_external_translated_test/migrate_external_translated_test.info.yml
+++ b/core/modules/migrate/tests/modules/migrate_external_translated_test/migrate_external_translated_test.info.yml
@@ -7,7 +7,7 @@ dependencies:
   - drupal:node
   - drupal:migrate
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/migrate/tests/modules/migrate_high_water_test/migrate_high_water_test.info.yml
+++ b/core/modules/migrate/tests/modules/migrate_high_water_test/migrate_high_water_test.info.yml
@@ -6,7 +6,7 @@ core: 8.x
 dependencies:
   - drupal:migrate
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/migrate/tests/modules/migrate_prepare_row_test/migrate_prepare_row_test.info.yml
+++ b/core/modules/migrate/tests/modules/migrate_prepare_row_test/migrate_prepare_row_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/migrate/tests/modules/migrate_query_batch_test/migrate_query_batch_test.info.yml
+++ b/core/modules/migrate/tests/modules/migrate_query_batch_test/migrate_query_batch_test.info.yml
@@ -6,7 +6,7 @@ core: 8.x
 dependencies:
   - drupal:migrate
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/migrate/tests/modules/migrate_track_changes_test/migrate_track_changes_test.info.yml
+++ b/core/modules/migrate/tests/modules/migrate_track_changes_test/migrate_track_changes_test.info.yml
@@ -6,7 +6,7 @@ core: 8.x
 dependencies:
   - drupal:migrate
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/migrate/tests/modules/migration_directory_test/migration_directory_test.info.yml
+++ b/core/modules/migrate/tests/modules/migration_directory_test/migration_directory_test.info.yml
@@ -6,7 +6,7 @@ core: 8.x
 dependencies:
   - drupal:migrate
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/migrate_drupal/migrate_drupal.info.yml
+++ b/core/modules/migrate_drupal/migrate_drupal.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:migrate
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/migrate_drupal/tests/modules/field_discovery_test/field_discovery_test.info.yml
+++ b/core/modules/migrate_drupal/tests/modules/field_discovery_test/field_discovery_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/migrate_drupal/tests/modules/migrate_cckfield_plugin_manager_test/migrate_cckfield_plugin_manager_test.info.yml
+++ b/core/modules/migrate_drupal/tests/modules/migrate_cckfield_plugin_manager_test/migrate_cckfield_plugin_manager_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/migrate_drupal/tests/modules/migrate_field_plugin_manager_test/migrate_field_plugin_manager_test.info.yml
+++ b/core/modules/migrate_drupal/tests/modules/migrate_field_plugin_manager_test/migrate_field_plugin_manager_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/migrate_drupal/tests/modules/migrate_overwrite_test/migrate_overwrite_test.info.yml
+++ b/core/modules/migrate_drupal/tests/modules/migrate_overwrite_test/migrate_overwrite_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/migrate_drupal_multilingual/migrate_drupal_multilingual.info.yml
+++ b/core/modules/migrate_drupal_multilingual/migrate_drupal_multilingual.info.yml
@@ -6,7 +6,7 @@ core: 8.x
 dependencies:
   - migrate_drupal
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/migrate_drupal_ui/migrate_drupal_ui.info.yml
+++ b/core/modules/migrate_drupal_ui/migrate_drupal_ui.info.yml
@@ -10,7 +10,7 @@ dependencies:
   - drupal:migrate_drupal
   - drupal:dblog
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/migrate_drupal_ui/tests/modules/migration_provider_test/migration_provider_test.info.yml
+++ b/core/modules/migrate_drupal_ui/tests/modules/migration_provider_test/migration_provider_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/node/node.info.yml
+++ b/core/modules/node/node.info.yml
@@ -8,7 +8,7 @@ configure: entity.node_type.collection
 dependencies:
   - drupal:text
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/node/tests/modules/node_access_test/node_access_test.info.yml
+++ b/core/modules/node/tests/modules/node_access_test/node_access_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/node/tests/modules/node_access_test_empty/node_access_test_empty.info.yml
+++ b/core/modules/node/tests/modules/node_access_test_empty/node_access_test_empty.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/node/tests/modules/node_access_test_language/node_access_test_language.info.yml
+++ b/core/modules/node/tests/modules/node_access_test_language/node_access_test_language.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
 - drupal:options
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/node/tests/modules/node_display_configurable_test/node_display_configurable_test.info.yml
+++ b/core/modules/node/tests/modules/node_display_configurable_test/node_display_configurable_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/node/tests/modules/node_test/node_test.info.yml
+++ b/core/modules/node/tests/modules/node_test/node_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/node/tests/modules/node_test_config/node_test_config.info.yml
+++ b/core/modules/node/tests/modules/node_test_config/node_test_config.info.yml
@@ -5,7 +5,7 @@ core: 8.x
 package: Testing
 # version: VERSION
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/node/tests/modules/node_test_exception/node_test_exception.info.yml
+++ b/core/modules/node/tests/modules/node_test_exception/node_test_exception.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/node/tests/modules/node_test_views/node_test_views.info.yml
+++ b/core/modules/node/tests/modules/node_test_views/node_test_views.info.yml
@@ -9,7 +9,7 @@ dependencies:
   - drupal:views
   - drupal:language
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/node/tests/node_access_test_auto_bubbling/node_access_test_auto_bubbling.info.yml
+++ b/core/modules/node/tests/node_access_test_auto_bubbling/node_access_test_auto_bubbling.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/options/options.info.yml
+++ b/core/modules/options/options.info.yml
@@ -8,7 +8,7 @@ dependencies:
   - drupal:field
   - drupal:text
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/options/tests/options_config_install_test/options_config_install_test.info.yml
+++ b/core/modules/options/tests/options_config_install_test/options_config_install_test.info.yml
@@ -8,7 +8,7 @@ dependencies:
   - drupal:node
   - drupal:options
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/options/tests/options_test/options_test.info.yml
+++ b/core/modules/options/tests/options_test/options_test.info.yml
@@ -5,7 +5,7 @@ core: 8.x
 package: Testing
 # version: VERSION
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/options/tests/options_test_views/options_test_views.info.yml
+++ b/core/modules/options/tests/options_test_views/options_test_views.info.yml
@@ -8,7 +8,7 @@ dependencies:
   - drupal:options
   - drupal:views
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/page_cache/page_cache.info.yml
+++ b/core/modules/page_cache/page_cache.info.yml
@@ -5,7 +5,7 @@ package: Core
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/page_cache/tests/modules/page_cache_form_test.info.yml
+++ b/core/modules/page_cache/tests/modules/page_cache_form_test.info.yml
@@ -5,7 +5,7 @@ core: 8.x
 package: Testing
 # version: VERSION
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/path/path.info.yml
+++ b/core/modules/path/path.info.yml
@@ -6,7 +6,7 @@ package: Core
 core: 8.x
 configure: path.admin_overview
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/quickedit/quickedit.info.yml
+++ b/core/modules/quickedit/quickedit.info.yml
@@ -9,7 +9,7 @@ dependencies:
   - drupal:field
   - drupal:filter
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/quickedit/tests/modules/quickedit_test.info.yml
+++ b/core/modules/quickedit/tests/modules/quickedit_test.info.yml
@@ -5,7 +5,7 @@ core: 8.x
 package: Testing
 # version: VERSION
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/rdf/rdf.info.yml
+++ b/core/modules/rdf/rdf.info.yml
@@ -5,7 +5,7 @@ package: Core
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/rdf/tests/rdf_conflicting_namespaces/rdf_conflicting_namespaces.info.yml
+++ b/core/modules/rdf/tests/rdf_conflicting_namespaces/rdf_conflicting_namespaces.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:rdf
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/rdf/tests/rdf_test/rdf_test.info.yml
+++ b/core/modules/rdf/tests/rdf_test/rdf_test.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - rdf
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/rdf/tests/rdf_test_namespaces/rdf_test_namespaces.info.yml
+++ b/core/modules/rdf/tests/rdf_test_namespaces/rdf_test_namespaces.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:rdf
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/responsive_image/responsive_image.info.yml
+++ b/core/modules/responsive_image/responsive_image.info.yml
@@ -9,7 +9,7 @@ dependencies:
   - drupal:image
 configure: entity.responsive_image_style.collection
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/responsive_image/tests/modules/responsive_image_test_module/responsive_image_test_module.info.yml
+++ b/core/modules/responsive_image/tests/modules/responsive_image_test_module/responsive_image_test_module.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/rest/rest.info.yml
+++ b/core/modules/rest/rest.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:serialization
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/rest/tests/modules/config_test_rest/config_test_rest.info.yml
+++ b/core/modules/rest/tests/modules/config_test_rest/config_test_rest.info.yml
@@ -6,7 +6,7 @@ core: 8.x
 dependencies:
   - drupal:config_test
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/rest/tests/modules/rest_test/rest_test.info.yml
+++ b/core/modules/rest/tests/modules/rest_test/rest_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/rest/tests/modules/rest_test_views/rest_test_views.info.yml
+++ b/core/modules/rest/tests/modules/rest_test_views/rest_test_views.info.yml
@@ -8,7 +8,7 @@ dependencies:
   - drupal:rest
   - drupal:views
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/search/search.info.yml
+++ b/core/modules/search/search.info.yml
@@ -6,7 +6,7 @@ package: Core
 core: 8.x
 configure: entity.search_page.collection
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/search/tests/modules/search_date_query_alter/search_date_query_alter.info.yml
+++ b/core/modules/search/tests/modules/search_date_query_alter/search_date_query_alter.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/search/tests/modules/search_embedded_form/search_embedded_form.info.yml
+++ b/core/modules/search/tests/modules/search_embedded_form/search_embedded_form.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/search/tests/modules/search_extra_type/search_extra_type.info.yml
+++ b/core/modules/search/tests/modules/search_extra_type/search_extra_type.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:test_page_test
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/search/tests/modules/search_langcode_test/search_langcode_test.info.yml
+++ b/core/modules/search/tests/modules/search_langcode_test/search_langcode_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/search/tests/modules/search_query_alter/search_query_alter.info.yml
+++ b/core/modules/search/tests/modules/search_query_alter/search_query_alter.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/serialization/serialization.info.yml
+++ b/core/modules/serialization/serialization.info.yml
@@ -5,7 +5,7 @@ package: Web services
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/serialization/tests/modules/entity_serialization_test/entity_serialization_test.info.yml
+++ b/core/modules/serialization/tests/modules/entity_serialization_test/entity_serialization_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/serialization/tests/modules/field_normalization_test/field_normalization_test.info.yml
+++ b/core/modules/serialization/tests/modules/field_normalization_test/field_normalization_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/serialization/tests/modules/test_datatype_boolean_emoji_normalizer/test_datatype_boolean_emoji_normalizer.info.yml
+++ b/core/modules/serialization/tests/modules/test_datatype_boolean_emoji_normalizer/test_datatype_boolean_emoji_normalizer.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/serialization/tests/modules/test_fieldtype_boolean_emoji_normalizer/test_fieldtype_boolean_emoji_normalizer.info.yml
+++ b/core/modules/serialization/tests/modules/test_fieldtype_boolean_emoji_normalizer/test_fieldtype_boolean_emoji_normalizer.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/serialization/tests/serialization_test/serialization_test.info.yml
+++ b/core/modules/serialization/tests/serialization_test/serialization_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/settings_tray/settings_tray.info.yml
+++ b/core/modules/settings_tray/settings_tray.info.yml
@@ -9,7 +9,7 @@ dependencies:
   - drupal:toolbar
   - drupal:contextual
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/settings_tray/tests/modules/settings_tray_override_test/settings_tray_override_test.info.yml
+++ b/core/modules/settings_tray/tests/modules/settings_tray_override_test/settings_tray_override_test.info.yml
@@ -6,7 +6,7 @@ core: 8.x
 dependencies:
   - drupal:settings_tray
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/settings_tray/tests/modules/settings_tray_test/settings_tray_test.info.yml
+++ b/core/modules/settings_tray/tests/modules/settings_tray_test/settings_tray_test.info.yml
@@ -8,7 +8,7 @@ dependencies:
   - drupal:block
   - drupal:settings_tray
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/settings_tray/tests/modules/settings_tray_test_css/settings_tray_test_css.info.yml
+++ b/core/modules/settings_tray/tests/modules/settings_tray_test_css/settings_tray_test_css.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
 - drupal:settings_tray
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/shortcut/shortcut.info.yml
+++ b/core/modules/shortcut/shortcut.info.yml
@@ -8,7 +8,7 @@ configure: entity.shortcut_set.collection
 dependencies:
   - drupal:link
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/simpletest/simpletest.info.yml
+++ b/core/modules/simpletest/simpletest.info.yml
@@ -6,7 +6,7 @@ package: Core
 core: 8.x
 configure: simpletest.settings
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/simpletest/tests/modules/simpletest_deprecation_test/simpletest_deprecation_test.info.yml
+++ b/core/modules/simpletest/tests/modules/simpletest_deprecation_test/simpletest_deprecation_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/statistics/statistics.info.yml
+++ b/core/modules/statistics/statistics.info.yml
@@ -8,7 +8,7 @@ configure: statistics.settings
 dependencies:
   - drupal:node
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/statistics/tests/modules/statistics_test_views/statistics_test_views.info.yml
+++ b/core/modules/statistics/tests/modules/statistics_test_views/statistics_test_views.info.yml
@@ -8,7 +8,7 @@ dependencies:
   - drupal:statistics
   - drupal:views
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/statistics/tests/themes/statistics_test_attached/statistics_test_attached.info.yml
+++ b/core/modules/statistics/tests/themes/statistics_test_attached/statistics_test_attached.info.yml
@@ -4,7 +4,7 @@ description: 'Theme for testing attached library'
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/syslog/syslog.info.yml
+++ b/core/modules/syslog/syslog.info.yml
@@ -6,7 +6,7 @@ package: Core
 core: 8.x
 configure: system.logging_settings
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/syslog/tests/modules/syslog_test/syslog_test.info.yml
+++ b/core/modules/syslog/tests/modules/syslog_test/syslog_test.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:syslog
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/src/Controller/DbUpdateController.php
+++ b/core/modules/system/src/Controller/DbUpdateController.php
@@ -144,7 +144,6 @@ class DbUpdateController extends ControllerBase {
     require_once $this->root . '/core/includes/update.inc';
 
     drupal_load_updates();
-    update_fix_compatibility();
 
     if ($request->query->get('continue')) {
       $_SESSION['update_ignore_warnings'] = TRUE;

--- a/core/modules/system/system.info.yml
+++ b/core/modules/system/system.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 required: true
 configure: system.admin_config_system
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/system.install
+++ b/core/modules/system/system.install
@@ -13,6 +13,7 @@ use Drupal\Component\Utility\Unicode;
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Path\AliasStorage;
+use Drupal\Core\StringTranslation\PluralTranslatableMarkup;
 use Drupal\Core\Url;
 use Drupal\Core\Database\Database;
 use Drupal\Core\Entity\ContentEntityTypeInterface;
@@ -31,6 +32,9 @@ use Symfony\Component\HttpFoundation\Request;
  */
 function system_requirements($phase) {
   global $install_state;
+  // Reset the extension lists.
+  \Drupal::service('extension.list.module')->reset();
+  \Drupal::service('extension.list.theme')->reset();
   $requirements = [];
 
   // Report Drupal version
@@ -795,28 +799,71 @@ function system_requirements($phase) {
   }
 
   // Display an error if a newly introduced dependency in a module is not resolved.
-  if ($phase == 'update') {
+  if ($phase === 'update'|| $phase === 'runtime') {
+    $create_extension_incompatibility_list = function ($extension_names, $description, $title) {
+      // Use an inline twig template to:
+      // - Concatenate two MarkupInterface objects and preserve safeness.
+      // - Use the item_list theme for the extension list.
+      $template = [
+        '#type' => 'inline_template',
+        '#template' => '{{ description }}{{ extensions }}',
+        '#context' => [
+          'extensions' => [
+            '#theme' => 'item_list',
+          ],
+        ],
+      ];
+      $template['#context']['extensions']['#items'] = $extension_names;
+      $template['#context']['description'] = $description;
+      return [
+        'title' => $title,
+        'value' => [
+          'list' => $template,
+          'handbook_link' => [
+            '#markup' => t(
+              'Review the <a href=":url"> suggestions for resolving this incompatibility</a> to repair your installation, and then re-run update.php.',
+              [':url' => 'https://www.drupal.org/docs/8/update/troubleshooting-database-updates']
+            ),
+          ],
+        ],
+        'severity' => REQUIREMENT_ERROR,
+      ];
+    };
     $profile = drupal_get_profile();
     $files = system_rebuild_module_data();
-    foreach ($files as $module => $file) {
+    $files += \Drupal::service('extension.list.theme')->getList();
+    $core_incompatible_extensions = [];
+    $php_incompatible_extensions = [];
+    foreach ($files as $extension_name => $file) {
       // Ignore disabled modules and installation profiles.
-      if (!$file->status || $module == $profile) {
+      if (!$file->status || $extension_name == $profile) {
         continue;
       }
-      // Check the module's PHP version.
+
       $name = $file->info['name'];
+      if (!empty($file->info['core_incompatible'])) {
+        $core_incompatible_extensions[$file->info['type']][] = $name;
+      }
+
+      // Check the module's PHP version.
       $php = $file->info['php'];
       if (version_compare($php, PHP_VERSION, '>')) {
-        $requirements['php']['description'] .= t('@name requires at least PHP @version.', ['@name' => $name, '@version' => $php]);
-        $requirements['php']['severity'] = REQUIREMENT_ERROR;
+        $php_incompatible_extensions[$file->info['type']][] = $name;
       }
+
+      // @todo Remove this 'if' block to allow checking requirements of themes
+      //   https://www.drupal.org/project/drupal/issues/474684.
+      if ($file->info['type'] !== 'module') {
+        continue;
+      }
+
       // Check the module's required modules.
       /** @var \Drupal\Core\Extension\Dependency $requirement */
       foreach ($file->requires as $requirement) {
         $required_module = $requirement->getName();
         // Check if the module exists.
         if (!isset($files[$required_module])) {
-          $requirements["$module-$required_module"] = [
+          $requirements["$extension_name-$required_module"] = [
             'title' => t('Unresolved dependency'),
             'description' => t('@name requires this module.', ['@name' => $name]),
             'value' => t('@required_name (Missing)', ['@required_name' => $required_module]),
@@ -829,7 +876,7 @@ function system_requirements($phase) {
         $required_name = $required_file->info['name'];
         $version = str_replace(\Drupal::CORE_COMPATIBILITY . '-', '', $required_file->info['version']);
         if (!$requirement->isCompatible($version)) {
-          $requirements["$module-$required_module"] = [
+          $requirements["$extension_name-$required_module"] = [
             'title' => t('Unresolved dependency'),
             'description' => t('@name requires this module and version. Currently using @required_name version @version', ['@name' => $name, '@required_name' => $required_name, '@version' => $version]),
             'value' => t('@required_name (Version @compatibility required)', ['@required_name' => $required_name, '@compatibility' => $requirement->getConstraintString()]),
@@ -838,6 +885,115 @@ function system_requirements($phase) {
           continue;
         }
       }
+    }
+    if (!empty($core_incompatible_extensions['module'])) {
+      $requirements['module_core_incompatible'] = $create_extension_incompatibility_list(
+        $core_incompatible_extensions['module'],
+        new PluralTranslatableMarkup(
+          count($core_incompatible_extensions['module']),
+        'The following module is installed, but it is incompatible with Drupal @version:',
+        'The following modules are installed, but they are incompatible with Drupal @version:',
+        ['@version' => \Drupal::VERSION]
+        ),
+        new PluralTranslatableMarkup(
+          count($core_incompatible_extensions['module']),
+          'Incompatible module',
+          'Incompatible modules'
+        )
+      );
+    }
+    if (!empty($core_incompatible_extensions['theme'])) {
+      $requirements['theme_core_incompatible'] = $create_extension_incompatibility_list(
+        $core_incompatible_extensions['theme'],
+        new PluralTranslatableMarkup(
+          count($core_incompatible_extensions['theme']),
+          'The following theme is installed, but it is incompatible with Drupal @version:',
+          'The following themes are installed, but they are incompatible with Drupal @version:',
+          ['@version' => \Drupal::VERSION]
+        ),
+        new PluralTranslatableMarkup(
+          count($core_incompatible_extensions['theme']),
+          'Incompatible theme',
+          'Incompatible themes'
+        )
+      );
+    }
+    if (!empty($php_incompatible_extensions['module'])) {
+      $requirements['module_php_incompatible'] = $create_extension_incompatibility_list(
+        $php_incompatible_extensions['module'],
+        new PluralTranslatableMarkup(
+          count($php_incompatible_extensions['module']),
+          'The following module is installed, but it is incompatible with PHP @version:',
+          'The following modules are installed, but they are incompatible with PHP @version:',
+          ['@version' => phpversion()]
+        ),
+        new PluralTranslatableMarkup(
+          count($php_incompatible_extensions['module']),
+          'Incompatible module',
+          'Incompatible modules'
+        )
+      );
+    }
+    if (!empty($php_incompatible_extensions['theme'])) {
+      $requirements['theme_php_incompatible'] = $create_extension_incompatibility_list(
+        $php_incompatible_extensions['theme'],
+        new PluralTranslatableMarkup(
+          count($php_incompatible_extensions['theme']),
+          'The following theme is installed, but it is incompatible with PHP @version:',
+          'The following themes are installed, but they are incompatible with PHP @version:',
+          ['@version' => phpversion()]
+        ),
+        new PluralTranslatableMarkup(
+          count($php_incompatible_extensions['theme']),
+          'Incompatible theme',
+          'Incompatible themes'
+        )
+      );
+    }
+
+    // Look for invalid modules.
+    $extension_config = \Drupal::configFactory()->get('core.extension');
+    /** @var \Drupal\Core\Extension\ExtensionList $extension_list */
+    $extension_list = \Drupal::service('extension.list.module');
+    $is_missing_extension = function ($extension_name) use (&$extension_list) {
+      return !$extension_list->exists($extension_name);
+    };
+
+    $invalid_modules = array_filter(array_keys($extension_config->get('module')), $is_missing_extension);
+
+    if (!empty($invalid_modules)) {
+      $requirements['invalid_module'] = $create_extension_incompatibility_list(
+        $invalid_modules,
+        new PluralTranslatableMarkup(
+          count($invalid_modules),
+          'The following module is marked as installed in the core.extension configuration, but it is missing:',
+          'The following modules are marked as installed in the core.extension configuration, but they are missing:'
+        ),
+        new PluralTranslatableMarkup(
+          count($invalid_modules),
+          'Missing or invalid module',
+          'Missing or invalid modules'
+        )
+      );
+    }
+
+    // Look for invalid themes.
+    $extension_list = \Drupal::service('extension.list.theme');
+    $invalid_themes = array_filter(array_keys($extension_config->get('theme')), $is_missing_extension);
+    if (!empty($invalid_themes)) {
+      $requirements['invalid_theme'] = $create_extension_incompatibility_list(
+        $invalid_themes,
+        new PluralTranslatableMarkup(
+          count($invalid_themes),
+          'The following theme is marked as installed in the core.extension configuration, but it is missing:',
+          'The following themes are marked as installed in the core.extension configuration, but they are missing:'
+        ),
+        new PluralTranslatableMarkup(
+          count($invalid_themes),
+          'Missing or invalid theme',
+          'Missing or invalid themes'
+        )
+      );
     }
   }
 

--- a/core/modules/system/system.post_update.php
+++ b/core/modules/system/system.post_update.php
@@ -98,6 +98,13 @@ function system_post_update_fix_jquery_extend() {
 }
 
 /**
+ * Clear the library cache and ensure aggregate files are regenerated.
+ */
+function system_post_update_fix_jquery_htmlprefilter() {
+  // Empty post-update hook.
+}
+
+/**
  * Change plugin IDs of actions.
  */
 function system_post_update_change_action_plugins() {

--- a/core/modules/system/tests/modules/accept_header_routing_test/accept_header_routing_test.info.yml
+++ b/core/modules/system/tests/modules/accept_header_routing_test/accept_header_routing_test.info.yml
@@ -4,7 +4,7 @@ type: module
 package: Testing
 # version: VERSION
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/action_test/action_test.info.yml
+++ b/core/modules/system/tests/modules/action_test/action_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/ajax_forms_test/ajax_forms_test.info.yml
+++ b/core/modules/system/tests/modules/ajax_forms_test/ajax_forms_test.info.yml
@@ -5,7 +5,7 @@ core: 8.x
 package: Testing
 # version: VERSION
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/ajax_test/ajax_test.info.yml
+++ b/core/modules/system/tests/modules/ajax_test/ajax_test.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:contact
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/batch_test/batch_test.info.yml
+++ b/core/modules/system/tests/modules/batch_test/batch_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/cache_test/cache_test.info.yml
+++ b/core/modules/system/tests/modules/cache_test/cache_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/common_test/common_test.info.yml
+++ b/core/modules/system/tests/modules/common_test/common_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/common_test_cron_helper/common_test_cron_helper.info.yml
+++ b/core/modules/system/tests/modules/common_test_cron_helper/common_test_cron_helper.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/condition_test/condition_test.info.yml
+++ b/core/modules/system/tests/modules/condition_test/condition_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/conneg_test/conneg_test.info.yml
+++ b/core/modules/system/tests/modules/conneg_test/conneg_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/cron_queue_test/cron_queue_test.info.yml
+++ b/core/modules/system/tests/modules/cron_queue_test/cron_queue_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/csrf_test/csrf_test.info.yml
+++ b/core/modules/system/tests/modules/csrf_test/csrf_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/css_disable_transitions_test/css_disable_transitions_test.info.yml
+++ b/core/modules/system/tests/modules/css_disable_transitions_test/css_disable_transitions_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/database_test/database_test.info.yml
+++ b/core/modules/system/tests/modules/database_test/database_test.info.yml
@@ -5,7 +5,7 @@ core: 8.x
 package: Testing
 # version: VERSION
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/default_format_test/default_format_test.info.yml
+++ b/core/modules/system/tests/modules/default_format_test/default_format_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/deprecation_test/deprecation_test.info.yml
+++ b/core/modules/system/tests/modules/deprecation_test/deprecation_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/dialog_renderer_test/dialog_renderer_test.info.yml
+++ b/core/modules/system/tests/modules/dialog_renderer_test/dialog_renderer_test.info.yml
@@ -5,7 +5,7 @@ core: 8.x
 package: Testing
 # version: VERSION
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/display_variant_test/display_variant_test.info.yml
+++ b/core/modules/system/tests/modules/display_variant_test/display_variant_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/drupal_system_listing_compatible_test/drupal_system_listing_compatible_test.info.yml
+++ b/core/modules/system/tests/modules/drupal_system_listing_compatible_test/drupal_system_listing_compatible_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/early_rendering_controller_test/early_rendering_controller_test.info.yml
+++ b/core/modules/system/tests/modules/early_rendering_controller_test/early_rendering_controller_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/element_info_test/element_info_test.info.yml
+++ b/core/modules/system/tests/modules/element_info_test/element_info_test.info.yml
@@ -4,7 +4,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/entity_crud_hook_test/entity_crud_hook_test.info.yml
+++ b/core/modules/system/tests/modules/entity_crud_hook_test/entity_crud_hook_test.info.yml
@@ -5,7 +5,7 @@ core: 8.x
 package: Testing
 # version: VERSION
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/entity_reference_test/entity_reference_test.info.yml
+++ b/core/modules/system/tests/modules/entity_reference_test/entity_reference_test.info.yml
@@ -10,7 +10,7 @@ dependencies:
   - drupal:views
   - drupal:entity_test
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/entity_reference_test_views/entity_reference_test_views.info.yml
+++ b/core/modules/system/tests/modules/entity_reference_test_views/entity_reference_test_views.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
  - drupal:views
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/entity_schema_test/entity_schema_test.info.yml
+++ b/core/modules/system/tests/modules/entity_schema_test/entity_schema_test.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:entity_test
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/entity_test/entity_test.info.yml
+++ b/core/modules/system/tests/modules/entity_test/entity_test.info.yml
@@ -8,7 +8,7 @@ dependencies:
   - drupal:field
   - drupal:text
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/entity_test_constraints/entity_test_constraints.info.yml
+++ b/core/modules/system/tests/modules/entity_test_constraints/entity_test_constraints.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:entity_test
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/entity_test_extra/entity_test_extra.info.yml
+++ b/core/modules/system/tests/modules/entity_test_extra/entity_test_extra.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:entity_test
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/entity_test_operation/entity_test_operation.info.yml
+++ b/core/modules/system/tests/modules/entity_test_operation/entity_test_operation.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/entity_test_revlog/entity_test_revlog.info.yml
+++ b/core/modules/system/tests/modules/entity_test_revlog/entity_test_revlog.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/entity_test_schema_converter/entity_test_schema_converter.info.yml
+++ b/core/modules/system/tests/modules/entity_test_schema_converter/entity_test_schema_converter.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:entity_test_update
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/entity_test_third_party/entity_test_third_party.info.yml
+++ b/core/modules/system/tests/modules/entity_test_third_party/entity_test_third_party.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:entity_test
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/entity_test_update/entity_test_update.info.yml
+++ b/core/modules/system/tests/modules/entity_test_update/entity_test_update.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/error_service_test/error_service_test.info.yml
+++ b/core/modules/system/tests/modules/error_service_test/error_service_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/error_test/error_test.info.yml
+++ b/core/modules/system/tests/modules/error_test/error_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/experimental_module_dependency_test/experimental_module_dependency_test.info.yml
+++ b/core/modules/system/tests/modules/experimental_module_dependency_test/experimental_module_dependency_test.info.yml
@@ -7,7 +7,7 @@ dependencies:
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/experimental_module_requirements_test/experimental_module_requirements_test.info.yml
+++ b/core/modules/system/tests/modules/experimental_module_requirements_test/experimental_module_requirements_test.info.yml
@@ -5,7 +5,7 @@ package: Core (Experimental)
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/experimental_module_test/experimental_module_test.info.yml
+++ b/core/modules/system/tests/modules/experimental_module_test/experimental_module_test.info.yml
@@ -5,7 +5,7 @@ package: Core (Experimental)
 # version: 8.y.x-unstable
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/form_test/form_test.info.yml
+++ b/core/modules/system/tests/modules/form_test/form_test.info.yml
@@ -8,7 +8,7 @@ dependencies:
   - file
   - filter
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/hold_test/hold_test.info.yml
+++ b/core/modules/system/tests/modules/hold_test/hold_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/httpkernel_test/httpkernel_test.info.yml
+++ b/core/modules/system/tests/modules/httpkernel_test/httpkernel_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/image_test/image_test.info.yml
+++ b/core/modules/system/tests/modules/image_test/image_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/invalid_module_name_over_the_maximum_allowed_character_length/invalid_module_name_over_the_maximum_allowed_character_length.info.yml
+++ b/core/modules/system/tests/modules/invalid_module_name_over_the_maximum_allowed_character_length/invalid_module_name_over_the_maximum_allowed_character_length.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/js_ajax_test/js_ajax_test.info.yml
+++ b/core/modules/system/tests/modules/js_ajax_test/js_ajax_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/js_message_test/js_message_test.info.yml
+++ b/core/modules/system/tests/modules/js_message_test/js_message_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/js_webassert_test/js_webassert_test.info.yml
+++ b/core/modules/system/tests/modules/js_webassert_test/js_webassert_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/keyvalue_test/keyvalue_test.info.yml
+++ b/core/modules/system/tests/modules/keyvalue_test/keyvalue_test.info.yml
@@ -8,7 +8,7 @@ hidden: true
 dependencies:
   - drupal:entity_test
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/layout_test/layout_test.info.yml
+++ b/core/modules/system/tests/modules/layout_test/layout_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/lazy_route_provider_install_test/lazy_route_provider_install_test.info.yml
+++ b/core/modules/system/tests/modules/lazy_route_provider_install_test/lazy_route_provider_install_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/link_generation_test/link_generation_test.info.yml
+++ b/core/modules/system/tests/modules/link_generation_test/link_generation_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/mail_html_test/mail_html_test.info.yml
+++ b/core/modules/system/tests/modules/mail_html_test/mail_html_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/menu_test/menu_test.info.yml
+++ b/core/modules/system/tests/modules/menu_test/menu_test.info.yml
@@ -8,7 +8,7 @@ dependencies:
   - drupal:test_page_test
   - drupal:menu_ui
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/module_autoload_test/module_autoload_test.info.yml
+++ b/core/modules/system/tests/modules/module_autoload_test/module_autoload_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/module_cachebin/module_cachebin.info.yml
+++ b/core/modules/system/tests/modules/module_cachebin/module_cachebin.info.yml
@@ -6,7 +6,7 @@ package: Testing
 core: 8.x
 hidden: true
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/module_handler_test_multiple/module_handler_test_multiple.info.yml
+++ b/core/modules/system/tests/modules/module_handler_test_multiple/module_handler_test_multiple.info.yml
@@ -6,7 +6,7 @@ package: Testing
 core: 8.x
 hidden: true
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/module_handler_test_multiple/module_handler_test_multiple_child/module_handler_test_multiple_child.info.yml
+++ b/core/modules/system/tests/modules/module_handler_test_multiple/module_handler_test_multiple_child/module_handler_test_multiple_child.info.yml
@@ -8,7 +8,7 @@ hidden: true
 dependencies:
   - drupal:module_handler_test_multiple
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/module_install_class_loader_test1/module_install_class_loader_test1.info.yml
+++ b/core/modules/system/tests/modules/module_install_class_loader_test1/module_install_class_loader_test1.info.yml
@@ -5,7 +5,7 @@ package: Testing
 core: 8.x
 # version: VERSION
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/module_install_class_loader_test2/module_install_class_loader_test2.info.yml
+++ b/core/modules/system/tests/modules/module_install_class_loader_test2/module_install_class_loader_test2.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:module_install_class_loader_test1
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/module_installer_config_test/module_installer_config_test.info.yml
+++ b/core/modules/system/tests/modules/module_installer_config_test/module_installer_config_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 core: 8.x
 # version: VERSION
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/module_required_test/module_required_test.info.yml
+++ b/core/modules/system/tests/modules/module_required_test/module_required_test.info.yml
@@ -10,7 +10,7 @@ core: 8.x
 dependencies:
   - drupal:node (>=8.x)
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/module_test/module_test.info.yml
+++ b/core/modules/system/tests/modules/module_test/module_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/new_dependency_test/new_dependency_test.info.yml
+++ b/core/modules/system/tests/modules/new_dependency_test/new_dependency_test.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - new_dependency_test_with_service
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/new_dependency_test_with_service/new_dependency_test_with_service.info.yml
+++ b/core/modules/system/tests/modules/new_dependency_test_with_service/new_dependency_test_with_service.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/off_canvas_test/off_canvas_test.info.yml
+++ b/core/modules/system/tests/modules/off_canvas_test/off_canvas_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/pager_test/pager_test.info.yml
+++ b/core/modules/system/tests/modules/pager_test/pager_test.info.yml
@@ -5,7 +5,7 @@ description: 'Support module for pager tests.'
 package: Testing
 # version: VERSION
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/paramconverter_test/paramconverter_test.info.yml
+++ b/core/modules/system/tests/modules/paramconverter_test/paramconverter_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/path_encoded_test/path_encoded_test.info.yml
+++ b/core/modules/system/tests/modules/path_encoded_test/path_encoded_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/path_test/path_test.info.yml
+++ b/core/modules/system/tests/modules/path_test/path_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/phpunit_test/phpunit_test.info.yml
+++ b/core/modules/system/tests/modules/phpunit_test/phpunit_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/plugin_test/plugin_test.info.yml
+++ b/core/modules/system/tests/modules/plugin_test/plugin_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/plugin_test_extended/plugin_test_extended.info.yml
+++ b/core/modules/system/tests/modules/plugin_test_extended/plugin_test_extended.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/render_array_non_html_subscriber_test/render_array_non_html_subscriber_test.info.yml
+++ b/core/modules/system/tests/modules/render_array_non_html_subscriber_test/render_array_non_html_subscriber_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/render_attached_test/render_attached_test.info.yml
+++ b/core/modules/system/tests/modules/render_attached_test/render_attached_test.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:block
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/render_placeholder_message_test/render_placeholder_message_test.info.yml
+++ b/core/modules/system/tests/modules/render_placeholder_message_test/render_placeholder_message_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/requirements1_test/requirements1_test.info.yml
+++ b/core/modules/system/tests/modules/requirements1_test/requirements1_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/requirements2_test/requirements2_test.info.yml
+++ b/core/modules/system/tests/modules/requirements2_test/requirements2_test.info.yml
@@ -8,7 +8,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/router_test_directory/router_test.info.yml
+++ b/core/modules/system/tests/modules/router_test_directory/router_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/service_provider_test/service_provider_test.info.yml
+++ b/core/modules/system/tests/modules/service_provider_test/service_provider_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/session_exists_cache_context_test/session_exists_cache_context_test.info.yml
+++ b/core/modules/system/tests/modules/session_exists_cache_context_test/session_exists_cache_context_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/session_test/session_test.info.yml
+++ b/core/modules/system/tests/modules/session_test/session_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/system_core_incompatible_semver_test/system_core_incompatible_semver_test.info.yml
+++ b/core/modules/system/tests/modules/system_core_incompatible_semver_test/system_core_incompatible_semver_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: 1.0.0
 core_version_requirement: ^7
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/system_core_semver_test/system_core_semver_test.info.yml
+++ b/core/modules/system/tests/modules/system_core_semver_test/system_core_semver_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: 1.0.0
 core_version_requirement: ^8
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/system_dependencies_test/system_dependencies_test.info.yml
+++ b/core/modules/system/tests/modules/system_dependencies_test/system_dependencies_test.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:_missing_dependency
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/system_incompatible_core_version_dependencies_test/system_incompatible_core_version_dependencies_test.info.yml
+++ b/core/modules/system/tests/modules/system_incompatible_core_version_dependencies_test/system_incompatible_core_version_dependencies_test.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:system_incompatible_core_version_test
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/system_incompatible_core_version_test/system_incompatible_core_version_test.info.yml
+++ b/core/modules/system/tests/modules/system_incompatible_core_version_test/system_incompatible_core_version_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 5.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/system_incompatible_core_version_test_1x/system_incompatible_core_version_test_1x.info.yml
+++ b/core/modules/system/tests/modules/system_incompatible_core_version_test_1x/system_incompatible_core_version_test_1x.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: 1.0.0
 core: 1.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/system_incompatible_module_version_dependencies_test/system_incompatible_module_version_dependencies_test.info.yml
+++ b/core/modules/system/tests/modules/system_incompatible_module_version_dependencies_test/system_incompatible_module_version_dependencies_test.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - 'drupal:system_incompatible_module_version_test (>2.0)'
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/system_incompatible_module_version_test/system_incompatible_module_version_test.info.yml
+++ b/core/modules/system/tests/modules/system_incompatible_module_version_test/system_incompatible_module_version_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: '1.0'
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/system_incompatible_php_version_test/system_incompatible_php_version_test.info.yml
+++ b/core/modules/system/tests/modules/system_incompatible_php_version_test/system_incompatible_php_version_test.info.yml
@@ -6,7 +6,7 @@ package: Testing
 core: 8.x
 php: 6502
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/system_mail_failure_test/system_mail_failure_test.info.yml
+++ b/core/modules/system/tests/modules/system_mail_failure_test/system_mail_failure_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/system_module_test/system_module_test.info.yml
+++ b/core/modules/system/tests/modules/system_module_test/system_module_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/system_project_namespace_test/system_project_namespace_test.info.yml
+++ b/core/modules/system/tests/modules/system_project_namespace_test/system_project_namespace_test.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:filter
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/system_test/system_test.info.yml
+++ b/core/modules/system/tests/modules/system_test/system_test.info.yml
@@ -8,7 +8,7 @@ configure: system_test.configure
 configure_parameters:
   foo: bar
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/tabledrag_test/tabledrag_test.info.yml
+++ b/core/modules/system/tests/modules/tabledrag_test/tabledrag_test.info.yml
@@ -5,7 +5,7 @@ core: 8.x
 package: Testing
 # version: VERSION
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/test_batch_test/test_batch_test.info.yml
+++ b/core/modules/system/tests/modules/test_batch_test/test_batch_test.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:entity_test
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/test_page_test/test_page_test.info.yml
+++ b/core/modules/system/tests/modules/test_page_test/test_page_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/theme_page_test/theme_page_test.info.yml
+++ b/core/modules/system/tests/modules/theme_page_test/theme_page_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/theme_region_test/theme_region_test.info.yml
+++ b/core/modules/system/tests/modules/theme_region_test/theme_region_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/theme_suggestions_test/theme_suggestions_test.info.yml
+++ b/core/modules/system/tests/modules/theme_suggestions_test/theme_suggestions_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/theme_test/theme_test.info.yml
+++ b/core/modules/system/tests/modules/theme_test/theme_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/token_test/token_test.info.yml
+++ b/core/modules/system/tests/modules/token_test/token_test.info.yml
@@ -7,7 +7,7 @@ dependencies:
  - drupal:user
  - drupal:node
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/trusted_hosts_test/trusted_hosts_test.info.yml
+++ b/core/modules/system/tests/modules/trusted_hosts_test/trusted_hosts_test.info.yml
@@ -4,7 +4,7 @@ core: 8.x
 package: Testing
 # version: VERSION
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/twig_extension_test/twig_extension_test.info.yml
+++ b/core/modules/system/tests/modules/twig_extension_test/twig_extension_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/twig_loader_test/twig_loader_test.info.yml
+++ b/core/modules/system/tests/modules/twig_loader_test/twig_loader_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/twig_theme_test/modules/twig_namespace_a/twig_namespace_a.info.yml
+++ b/core/modules/system/tests/modules/twig_theme_test/modules/twig_namespace_a/twig_namespace_a.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/twig_theme_test/modules/twig_namespace_b/twig_namespace_b.info.yml
+++ b/core/modules/system/tests/modules/twig_theme_test/modules/twig_namespace_b/twig_namespace_b.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/twig_theme_test/twig_theme_test.info.yml
+++ b/core/modules/system/tests/modules/twig_theme_test/twig_theme_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/unique_field_constraint_test/unique_field_constraint_test.info.yml
+++ b/core/modules/system/tests/modules/unique_field_constraint_test/unique_field_constraint_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/update_script_test/update_script_test.info.yml
+++ b/core/modules/system/tests/modules/update_script_test/update_script_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/update_test_0/update_test_0.info.yml
+++ b/core/modules/system/tests/modules/update_test_0/update_test_0.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/update_test_1/update_test_1.info.yml
+++ b/core/modules/system/tests/modules/update_test_1/update_test_1.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/update_test_2/update_test_2.info.yml
+++ b/core/modules/system/tests/modules/update_test_2/update_test_2.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/update_test_3/update_test_3.info.yml
+++ b/core/modules/system/tests/modules/update_test_3/update_test_3.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/update_test_failing/update_test_failing.info.yml
+++ b/core/modules/system/tests/modules/update_test_failing/update_test_failing.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/update_test_invalid_hook/update_test_invalid_hook.info.yml
+++ b/core/modules/system/tests/modules/update_test_invalid_hook/update_test_invalid_hook.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/update_test_postupdate/update_test_postupdate.info.yml
+++ b/core/modules/system/tests/modules/update_test_postupdate/update_test_postupdate.info.yml
@@ -4,7 +4,7 @@ type: module
 package: Testing
 # version: VERSION
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/update_test_schema/update_test_schema.info.yml
+++ b/core/modules/system/tests/modules/update_test_schema/update_test_schema.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/update_test_semver_update_n/update_test_semver_update_n.info.yml
+++ b/core/modules/system/tests/modules/update_test_semver_update_n/update_test_semver_update_n.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core_version_requirement: ^8
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/update_test_with_7x/update_test_with_7x.info.yml
+++ b/core/modules/system/tests/modules/update_test_with_7x/update_test_with_7x.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/modules/url_alter_test/url_alter_test.info.yml
+++ b/core/modules/system/tests/modules/url_alter_test/url_alter_test.info.yml
@@ -5,7 +5,7 @@ core: 8.x
 package: Testing
 # version: VERSION
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/src/Functional/Entity/Traits/EntityDefinitionTestTrait.php
+++ b/core/modules/system/tests/src/Functional/Entity/Traits/EntityDefinitionTestTrait.php
@@ -311,12 +311,18 @@ trait EntityDefinitionTestTrait {
    *
    * @param string $type
    *   (optional) The field type for the new field. Defaults to 'string'.
+   * @param bool $revisionable
+   *   (optional) Whether the field should be revisionable. Defaults to FALSE.
+   * @param bool $translatable
+   *   (optional) Whether the field should be translatable. Defaults to FALSE.
    */
-  protected function addBundleField($type = 'string') {
+  protected function addBundleField($type = 'string', $revisionable = FALSE, $translatable = FALSE) {
     $definitions['new_bundle_field'] = FieldStorageDefinition::create($type)
       ->setName('new_bundle_field')
       ->setLabel(t('A new bundle field'))
-      ->setTargetEntityTypeId('entity_test_update');
+      ->setTargetEntityTypeId('entity_test_update')
+      ->setRevisionable($revisionable)
+      ->setTranslatable($translatable);
     $this->state->set('entity_test_update.additional_field_storage_definitions', $definitions);
     $this->state->set('entity_test_update.additional_bundle_field_definitions.test_bundle', $definitions);
   }

--- a/core/modules/system/tests/src/Functional/Update/UpdateScriptTest.php
+++ b/core/modules/system/tests/src/Functional/Update/UpdateScriptTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\system\Functional\Update;
 
+use Drupal\Component\Serialization\Yaml;
 use Drupal\Core\Url;
 use Drupal\language\Entity\ConfigurableLanguage;
 use Drupal\Tests\BrowserTestBase;
@@ -16,6 +17,8 @@ class UpdateScriptTest extends BrowserTestBase {
 
   use RequirementsPageTrait;
 
+  const HANDBOOK_MESSAGE = 'Review the suggestions for resolving this incompatibility to repair your installation, and then re-run update.php.';
+
   /**
    * Modules to enable.
    *
@@ -27,6 +30,13 @@ class UpdateScriptTest extends BrowserTestBase {
    * {@inheritdoc}
    */
   protected $dumpHeaders = TRUE;
+
+  /**
+   * The URL to the status report page.
+   *
+   * @var \Drupal\Core\Url
+   */
+  protected $statusReportUrl;
 
   /**
    * URL to the update.php script.
@@ -45,6 +55,7 @@ class UpdateScriptTest extends BrowserTestBase {
   protected function setUp() {
     parent::setUp();
     $this->updateUrl = Url::fromRoute('system.db_update');
+    $this->statusReportUrl = Url::fromRoute('system.status');
     $this->updateUser = $this->drupalCreateUser(['administer software updates', 'access site in maintenance mode']);
   }
 
@@ -159,6 +170,227 @@ class UpdateScriptTest extends BrowserTestBase {
     $this->drupalGet($this->updateUrl, ['external' => TRUE]);
     $this->assertSession()->assertEscaped('Node (Version <7.x-0.0-dev required)');
     $this->assertSession()->responseContains('Update script test requires this module and version. Currently using Node version ' . \Drupal::VERSION);
+  }
+
+  /**
+   * Tests that extension compatibility changes are handled correctly.
+   *
+   * @param array $correct_info
+   *   The initial values for info.yml fail. These should compatible with core.
+   * @param array $breaking_info
+   *   The values to the info.yml that are not compatible with core.
+   * @param string $expected_error
+   *   The expected error.
+   *
+   * @dataProvider providerExtensionCompatibilityChange
+   */
+  public function testExtensionCompatibilityChange(array $correct_info, array $breaking_info, $expected_error) {
+    $extension_type = $correct_info['type'];
+    $this->drupalLogin(
+      $this->drupalCreateUser(
+        [
+          'administer software updates',
+          'administer site configuration',
+          $extension_type === 'module' ? 'administer modules' : 'administer themes',
+        ]
+      )
+    );
+
+    $extension_machine_name = "changing_extension";
+    $extension_name = "$extension_machine_name name";
+
+    $test_error_text = "Incompatible $extension_type "
+      . $expected_error
+      . $extension_name
+      . static::HANDBOOK_MESSAGE;
+    $base_info = ['name' => $extension_name];
+    if ($extension_type === 'theme') {
+      $base_info['base theme'] = FALSE;
+    }
+    $folder_path = \Drupal::service('site.path') . "/{$extension_type}s/$extension_machine_name";
+    $file_path = "$folder_path/$extension_machine_name.info.yml";
+    mkdir($folder_path, 0777, TRUE);
+    file_put_contents($file_path, Yaml::encode($base_info + $correct_info));
+    $this->enableExtension($extension_type, $extension_machine_name, $extension_name);
+    $this->assertInstalledExtensionConfig($extension_type, $extension_machine_name);
+
+    // If there are no requirements warnings or errors, we expect to be able to
+    // go through the update process uninterrupted.
+    $this->assertUpdateWithNoError($test_error_text, $extension_type, $extension_machine_name);
+
+    // Change the values in the info.yml and confirm updating is not possible.
+    file_put_contents($file_path, Yaml::encode($base_info + $breaking_info));
+    $this->assertErrorOnUpdate($test_error_text, $extension_type, $extension_machine_name);
+
+    // Fix the values in the info.yml file and confirm updating is possible
+    // again.
+    file_put_contents($file_path, Yaml::encode($base_info + $correct_info));
+    $this->assertUpdateWithNoError($test_error_text, $extension_type, $extension_machine_name);
+  }
+
+  /**
+   * Date provider for testExtensionCompatibilityChange().
+   */
+  public function providerExtensionCompatibilityChange() {
+    $incompatible_module_message = "The following module is installed, but it is incompatible with Drupal " . \Drupal::VERSION . ":";
+    $incompatible_theme_message = "The following theme is installed, but it is incompatible with Drupal " . \Drupal::VERSION . ":";
+    return [
+      'module: core key incompatible' => [
+        [
+          'core_version_requirement' => '^8 || ^9',
+          'type' => 'module',
+        ],
+        [
+          'core' => '7.x',
+          'type' => 'module',
+        ],
+        $incompatible_module_message,
+      ],
+      'module: core_version_requirement key incompatible' => [
+        [
+          'core_version_requirement' => '^8 || ^9',
+          'type' => 'module',
+        ],
+        [
+          'core_version_requirement' => '8.7.7',
+          'type' => 'module',
+        ],
+        $incompatible_module_message,
+      ],
+      'theme: core key incompatible' => [
+        [
+          'core_version_requirement' => '^8 || ^9',
+          'type' => 'theme',
+        ],
+        [
+          'core' => '7.x',
+          'type' => 'theme',
+        ],
+        $incompatible_theme_message,
+      ],
+      'theme: core_version_requirement key incompatible' => [
+        [
+          'core_version_requirement' => '^8 || ^9',
+          'type' => 'theme',
+        ],
+        [
+          'core_version_requirement' => '8.7.7',
+          'type' => 'theme',
+        ],
+        $incompatible_theme_message,
+      ],
+      'module: php requirement' => [
+        [
+          'core_version_requirement' => '^8 || ^9',
+          'type' => 'module',
+          'php' => 1,
+        ],
+        [
+          'core_version_requirement' => '^8 || ^9',
+          'type' => 'module',
+          'php' => 1000000000,
+        ],
+        'The following module is installed, but it is incompatible with PHP ' . phpversion() . ":",
+      ],
+      'theme: php requirement' => [
+        [
+          'core_version_requirement' => '^8 || ^9',
+          'type' => 'theme',
+          'php' => 1,
+        ],
+        [
+          'core_version_requirement' => '^8 || ^9',
+          'type' => 'theme',
+          'php' => 1000000000,
+        ],
+        'The following theme is installed, but it is incompatible with PHP ' . phpversion() . ":",
+      ],
+    ];
+  }
+
+  /**
+   * Tests that a missing extension prevents updates.
+   *
+   * @param string $extension_type
+   *   The extension type, either 'module' or 'theme'.
+   *
+   * @dataProvider providerMissingExtension
+   */
+  public function testMissingExtension($extension_type) {
+    $this->drupalLogin(
+      $this->drupalCreateUser(
+        [
+          'administer software updates',
+          'administer site configuration',
+          $extension_type === 'module' ? 'administer modules' : 'administer themes',
+        ]
+      )
+    );
+    $extension_machine_name = "disappearing_$extension_type";
+    $extension_name = 'The magically disappearing extension';
+    $test_error_text = "Missing or invalid $extension_type "
+      . "The following $extension_type is marked as installed in the core.extension configuration, but it is missing:"
+      . $extension_machine_name
+      . static::HANDBOOK_MESSAGE;
+    $extension_info = [
+      'name' => $extension_name,
+      'type' => $extension_type,
+      'core_version_requirement' => '^8 || ^9',
+    ];
+    if ($extension_type === 'theme') {
+      $extension_info['base theme'] = FALSE;
+    }
+    $folder_path = \Drupal::service('site.path') . "/{$extension_type}s/$extension_machine_name";
+    $file_path = "$folder_path/$extension_machine_name.info.yml";
+    mkdir($folder_path, 0777, TRUE);
+    file_put_contents($file_path, Yaml::encode($extension_info));
+    $this->enableExtension($extension_type, $extension_machine_name, $extension_name);
+
+    // If there are no requirements warnings or errors, we expect to be able to
+    // go through the update process uninterrupted.
+    $this->assertUpdateWithNoError($test_error_text, $extension_type, $extension_machine_name);
+
+    // Delete the info.yml and confirm updates are prevented.
+    unlink($file_path);
+    $this->assertErrorOnUpdate($test_error_text, $extension_type, $extension_machine_name);
+
+    // Add the info.yml file back and confirm we are able to go through the
+    // update process uninterrupted.
+    file_put_contents($file_path, Yaml::encode($extension_info));
+    $this->assertUpdateWithNoError($test_error_text, $extension_type, $extension_machine_name);
+  }
+
+  /**
+   * Data provider for testMissingExtension().
+   */
+  public function providerMissingExtension() {
+    return [
+      'module' => ['module'],
+      'theme' => ['theme'],
+    ];
+  }
+
+  /**
+   * Enables an extension using the UI.
+   *
+   * @param string $extension_type
+   *   The extension type.
+   * @param string $extension_machine_name
+   *   The extension machine name.
+   * @param string $extension_name
+   *   The extension name.
+   */
+  protected function enableExtension($extension_type, $extension_machine_name, $extension_name) {
+    if ($extension_type === 'module') {
+      $edit = [
+        "modules[$extension_machine_name][enable]" => $extension_machine_name,
+      ];
+      $this->drupalPostForm('admin/modules', $edit, t('Install'));
+    }
+    elseif ($extension_type === 'theme') {
+      $this->drupalGet('admin/appearance');
+      $this->click("a[title~=\"$extension_name\"]");
+    }
   }
 
   /**
@@ -424,6 +656,71 @@ class UpdateScriptTest extends BrowserTestBase {
         'type_name' => ['type', 'name'],
       ],
     ];
+  }
+
+  /**
+   * Asserts that an installed extension's config setting is correct.
+   *
+   * @param string $extension_type
+   *   The extension type, either 'module' or 'theme'.
+   * @param string $extension_machine_name
+   *   The extension machine name.
+   */
+  protected function assertInstalledExtensionConfig($extension_type, $extension_machine_name) {
+    $extension_config = $this->container->get('config.factory')->getEditable('core.extension');
+    $this->assertSame(0, $extension_config->get("$extension_type.$extension_machine_name"));
+  }
+
+  /**
+   * Asserts a particular error is not shown on update and status report pages.
+   *
+   * @param string $unexpected_error_text
+   *   The error text that should not be shown.
+   * @param string $extension_type
+   *   The extension type, either 'module' or 'theme'.
+   * @param string $extension_machine_name
+   *   The extension machine name.
+   *
+   * @throws \Behat\Mink\Exception\ResponseTextException
+   */
+  protected function assertUpdateWithNoError($unexpected_error_text, $extension_type, $extension_machine_name) {
+    $assert_session = $this->assertSession();
+    $this->drupalGet($this->statusReportUrl);
+    $this->assertSession()->pageTextNotContains($unexpected_error_text);
+    $this->drupalGet($this->updateUrl, ['external' => TRUE]);
+    $this->assertSession()->pageTextNotContains($unexpected_error_text);
+    $this->updateRequirementsProblem();
+    $this->clickLink(t('Continue'));
+    $assert_session->pageTextContains('No pending updates.');
+    $this->assertInstalledExtensionConfig($extension_type, $extension_machine_name);
+  }
+
+  /**
+   * Asserts an error is shown on the update and status report pages.
+   *
+   * @param string $expected_error_text
+   *   The expected error text.
+   * @param string $extension_type
+   *   The extension type, either 'module' or 'theme'.
+   * @param string $extension_machine_name
+   *   The extension machine name.
+   *
+   * @throws \Behat\Mink\Exception\ExpectationException
+   * @throws \Behat\Mink\Exception\ResponseTextException
+   */
+  protected function assertErrorOnUpdate($expected_error_text, $extension_type, $extension_machine_name) {
+    $assert_session = $this->assertSession();
+    $this->drupalGet($this->statusReportUrl);
+    $this->assertSession()->pageTextContains($expected_error_text);
+
+    // Reload the update page to ensure the extension with the breaking values
+    // has not been uninstalled or otherwise affected.
+    for ($reload = 0; $reload <= 1; $reload++) {
+      $this->drupalGet($this->updateUrl, ['external' => TRUE]);
+      $this->assertSession()->pageTextContains($expected_error_text);
+      $assert_session->linkNotExists('Continue');
+    }
+    $this->assertInstalledExtensionConfig($extension_type, $extension_machine_name);
   }
 
 }

--- a/core/modules/system/tests/themes/engines/nyan_cat/nyan_cat.info.yml
+++ b/core/modules/system/tests/themes/engines/nyan_cat/nyan_cat.info.yml
@@ -4,7 +4,7 @@ core: 8.x
 # version: VERSION
 package: Core
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/themes/test_basetheme/test_basetheme.info.yml
+++ b/core/modules/system/tests/themes/test_basetheme/test_basetheme.info.yml
@@ -23,7 +23,7 @@ libraries-extend:
   classy/base:
     - test_basetheme/global-styling
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/themes/test_ckeditor_stylesheets_external/test_ckeditor_stylesheets_external.info.yml
+++ b/core/modules/system/tests/themes/test_ckeditor_stylesheets_external/test_ckeditor_stylesheets_external.info.yml
@@ -8,7 +8,7 @@ core: 8.x
 ckeditor_stylesheets:
   - https://fonts.googleapis.com/css?family=Open+Sans
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/themes/test_ckeditor_stylesheets_protocol_relative/test_ckeditor_stylesheets_protocol_relative.info.yml
+++ b/core/modules/system/tests/themes/test_ckeditor_stylesheets_protocol_relative/test_ckeditor_stylesheets_protocol_relative.info.yml
@@ -8,7 +8,7 @@ core: 8.x
 ckeditor_stylesheets:
   - //fonts.googleapis.com/css?family=Open+Sans
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/themes/test_ckeditor_stylesheets_relative/test_ckeditor_stylesheets_relative.info.yml
+++ b/core/modules/system/tests/themes/test_ckeditor_stylesheets_relative/test_ckeditor_stylesheets_relative.info.yml
@@ -8,7 +8,7 @@ core: 8.x
 ckeditor_stylesheets:
   - css/yokotsoko.css
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/themes/test_core_semver/test_core_semver.info.yml
+++ b/core/modules/system/tests/themes/test_core_semver/test_core_semver.info.yml
@@ -4,7 +4,7 @@ description: 'Test theme which has semver core version.'
 # version: VERSION
 core_version_requirement: ^8 || ^9
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/themes/test_invalid_basetheme/test_invalid_basetheme.info.yml
+++ b/core/modules/system/tests/themes/test_invalid_basetheme/test_invalid_basetheme.info.yml
@@ -5,7 +5,7 @@ description: 'Test theme which has a non-existent base theme.'
 core: 8.x
 base theme: not_real_test_basetheme
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/themes/test_invalid_basetheme_sub/test_invalid_basetheme_sub.info.yml
+++ b/core/modules/system/tests/themes/test_invalid_basetheme_sub/test_invalid_basetheme_sub.info.yml
@@ -5,7 +5,7 @@ description: 'Test theme which has a non-existent base theme in the base chain.'
 core: 8.x
 base theme: test_invalid_basetheme
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/themes/test_invalid_core/test_invalid_core.info.yml
+++ b/core/modules/system/tests/themes/test_invalid_core/test_invalid_core.info.yml
@@ -4,7 +4,7 @@ description: 'Test theme which has an invalid core version.'
 # version: VERSION
 core: 7.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/themes/test_invalid_core_semver/test_invalid_core_semver.info.yml
+++ b/core/modules/system/tests/themes/test_invalid_core_semver/test_invalid_core_semver.info.yml
@@ -4,7 +4,7 @@ description: 'Test theme which has an invalid semver core version.'
 # version: VERSION
 core_version_requirement: ^7
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/themes/test_invalid_engine/test_invalid_engine.info.yml
+++ b/core/modules/system/tests/themes/test_invalid_engine/test_invalid_engine.info.yml
@@ -6,7 +6,7 @@ core: 8.x
 engine: not_real_engine
 base theme: false
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/themes/test_invalid_region/test_invalid_region.info.yml
+++ b/core/modules/system/tests/themes/test_invalid_region/test_invalid_region.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 regions:
   - foo: Foo
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/themes/test_messages/test_messages.info.yml
+++ b/core/modules/system/tests/themes/test_messages/test_messages.info.yml
@@ -5,7 +5,7 @@ description: 'Test theme which provides another div for messages.'
 core: 8.x
 base theme: classy
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/themes/test_stable/test_stable.info.yml
+++ b/core/modules/system/tests/themes/test_stable/test_stable.info.yml
@@ -4,7 +4,7 @@ description: A theme to test that stable is set as the default.
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/themes/test_subseven/test_subseven.info.yml
+++ b/core/modules/system/tests/themes/test_subseven/test_subseven.info.yml
@@ -5,7 +5,7 @@ description: 'Test theme which uses seven as the base theme.'
 core: 8.x
 base theme: seven
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/themes/test_subsubtheme/test_subsubtheme.info.yml
+++ b/core/modules/system/tests/themes/test_subsubtheme/test_subsubtheme.info.yml
@@ -5,7 +5,7 @@ description: 'Test theme which uses test_subtheme as the base theme.'
 core: 8.x
 base theme: test_subtheme
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/themes/test_subtheme/test_subtheme.info.yml
+++ b/core/modules/system/tests/themes/test_subtheme/test_subtheme.info.yml
@@ -14,7 +14,7 @@ libraries-extend:
   classy/base:
     - test_subtheme/global-styling
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/themes/test_theme/test_theme.info.yml
+++ b/core/modules/system/tests/themes/test_theme/test_theme.info.yml
@@ -67,7 +67,7 @@ regions:
   left: Left
   right: Right
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/themes/test_theme_having_veery_long_name_which_is_too_long/test_theme_having_veery_long_name_which_is_too_long.info.yml
+++ b/core/modules/system/tests/themes/test_theme_having_veery_long_name_which_is_too_long/test_theme_having_veery_long_name_which_is_too_long.info.yml
@@ -3,7 +3,7 @@ core: 8.x
 name: 'Test theme with a too long name'
 # version: VERSION
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/themes/test_theme_libraries_empty/test_theme_libraries_empty.info.yml
+++ b/core/modules/system/tests/themes/test_theme_libraries_empty/test_theme_libraries_empty.info.yml
@@ -6,7 +6,7 @@ base theme: classy
 core: 8.x
 libraries:
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/themes/test_theme_libraries_extend/test_theme_libraries_extend.info.yml
+++ b/core/modules/system/tests/themes/test_theme_libraries_extend/test_theme_libraries_extend.info.yml
@@ -14,7 +14,7 @@ libraries-extend:
     - not_a_string:
         expected: 'an exception'
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/themes/test_theme_libraries_override_with_drupal_settings/test_theme_libraries_override_with_drupal_settings.info.yml
+++ b/core/modules/system/tests/themes/test_theme_libraries_override_with_drupal_settings/test_theme_libraries_override_with_drupal_settings.info.yml
@@ -11,7 +11,7 @@ libraries-override:
     drupalSettings:
       ajaxPageState: { }
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/themes/test_theme_libraries_override_with_invalid_asset/test_theme_libraries_override_with_invalid_asset.info.yml
+++ b/core/modules/system/tests/themes/test_theme_libraries_override_with_invalid_asset/test_theme_libraries_override_with_invalid_asset.info.yml
@@ -10,7 +10,7 @@ libraries-override:
   core/drupal.dialog:
     css: false
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/themes/test_theme_nyan_cat_engine/test_theme_nyan_cat_engine.info.yml
+++ b/core/modules/system/tests/themes/test_theme_nyan_cat_engine/test_theme_nyan_cat_engine.info.yml
@@ -6,7 +6,7 @@ core: 8.x
 engine: nyan_cat
 base theme: false
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/themes/test_theme_settings/test_theme_settings.info.yml
+++ b/core/modules/system/tests/themes/test_theme_settings/test_theme_settings.info.yml
@@ -5,7 +5,7 @@ description: 'Test theme that extends theme settings options via theme-settings.
 core: 8.x
 base theme: false
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/themes/test_theme_settings_features/test_theme_settings_features.info.yml
+++ b/core/modules/system/tests/themes/test_theme_settings_features/test_theme_settings_features.info.yml
@@ -7,7 +7,7 @@ features:
   - comment_user_picture
   - comment_user_verification
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/themes/test_theme_theme/test_theme_theme.info.yml
+++ b/core/modules/system/tests/themes/test_theme_theme/test_theme_theme.info.yml
@@ -5,7 +5,7 @@ description: 'Test theme that extends theme settings options via theme.theme fil
 core: 8.x
 base theme: false
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/themes/test_theme_twig_registry_loader/test_theme_twig_registry_loader.info.yml
+++ b/core/modules/system/tests/themes/test_theme_twig_registry_loader/test_theme_twig_registry_loader.info.yml
@@ -4,7 +4,7 @@ description: 'Support module for Twig registry loader testing.'
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/themes/test_theme_twig_registry_loader_subtheme/test_theme_twig_registry_loader_subtheme.info.yml
+++ b/core/modules/system/tests/themes/test_theme_twig_registry_loader_subtheme/test_theme_twig_registry_loader_subtheme.info.yml
@@ -5,7 +5,7 @@ description: 'Support module for Twig registry loader testing.'
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/themes/test_theme_twig_registry_loader_theme/test_theme_twig_registry_loader_theme.info.yml
+++ b/core/modules/system/tests/themes/test_theme_twig_registry_loader_theme/test_theme_twig_registry_loader_theme.info.yml
@@ -5,7 +5,7 @@ description: 'Support module for Twig registry loader testing.'
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/system/tests/themes/test_wild_west/test_wild_west.info.yml
+++ b/core/modules/system/tests/themes/test_wild_west/test_wild_west.info.yml
@@ -5,7 +5,7 @@ description: A theme that doesn't use Stable as its base. It tests the wild west
 base theme: false
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/taxonomy/taxonomy.info.yml
+++ b/core/modules/taxonomy/taxonomy.info.yml
@@ -9,7 +9,7 @@ dependencies:
   - drupal:text
 configure: entity.taxonomy_vocabulary.collection
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/taxonomy/taxonomy.install
+++ b/core/modules/taxonomy/taxonomy.install
@@ -10,6 +10,40 @@ use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Site\Settings;
 
 /**
+ * Implements hook_requirements().
+ */
+function taxonomy_requirements($phase) {
+  $requirements = [];
+
+  if ($phase === 'update') {
+    // Check for invalid data before making terms revisionable.
+    /** @var \Drupal\Core\Update\UpdateRegistry $registry */
+    $registry = \Drupal::service('update.post_update_registry');
+    $update_name = 'taxonomy_post_update_make_taxonomy_term_revisionable';
+    if (in_array($update_name, $registry->getPendingUpdateFunctions(), TRUE)) {
+      // The 'name' field is non-NULL - if we get a NULL value that indicates a
+      // failure to join on taxonomy_term_field_data.
+      $is_broken = \Drupal::entityQuery('taxonomy_term')
+        ->condition('name', NULL, 'IS NULL')
+        ->range(0, 1)
+        ->accessCheck(FALSE)
+        ->execute();
+      if ($is_broken) {
+        $requirements[$update_name] = [
+          'title' => t('Taxonomy term data'),
+          'value' => t('Integrity issues detected'),
+          'description' => t('The make_taxonomy_term_revisionable database update cannot be run until the data has been fixed. See the <a href=":change_record">change record</a> for more information.', [
+            ':change_record' => 'https://www.drupal.org/node/3117753',
+          ]),
+          'severity' => REQUIREMENT_ERROR,
+        ];
+      }
+    }
+  }
+  return $requirements;
+}
+
+/**
  * Convert the custom taxonomy term hierarchy storage to a default storage.
  */
 function taxonomy_update_8501() {

--- a/core/modules/taxonomy/taxonomy.post_update.php
+++ b/core/modules/taxonomy/taxonomy.post_update.php
@@ -7,7 +7,12 @@
 
 use Drupal\Core\Config\Entity\ConfigEntityUpdater;
 use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\Logger\RfcLogLevel;
+use Drupal\Core\Site\Settings;
+use Drupal\Core\StringTranslation\PluralTranslatableMarkup;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\Url;
+use Drupal\taxonomy\TermStorage;
 use Drupal\views\ViewExecutable;
 
 /**
@@ -146,6 +151,12 @@ function taxonomy_post_update_remove_hierarchy_from_vocabularies(&$sandbox = NUL
  * Update taxonomy terms to be revisionable.
  */
 function taxonomy_post_update_make_taxonomy_term_revisionable(&$sandbox) {
+  $finished = _taxonomy_post_update_make_taxonomy_term_revisionable__fix_default_langcode($sandbox);
+  if (!$finished) {
+    $sandbox['#finished'] = 0;
+    return NULL;
+  }
+
   $definition_update_manager = \Drupal::entityDefinitionUpdateManager();
   /** @var \Drupal\Core\Entity\EntityLastInstalledSchemaRepositoryInterface $last_installed_schema_repository */
   $last_installed_schema_repository = \Drupal::service('entity.last_installed_schema.repository');
@@ -230,5 +241,105 @@ function taxonomy_post_update_make_taxonomy_term_revisionable(&$sandbox) {
 
   $definition_update_manager->updateFieldableEntityType($entity_type, $field_storage_definitions, $sandbox);
 
-  return t('Taxonomy terms have been converted to be revisionable.');
+  if (!empty($sandbox['data_fix']['default_langcode']['processed'])) {
+    $count = $sandbox['data_fix']['default_langcode']['processed'];
+    if (\Drupal::moduleHandler()->moduleExists('dblog')) {
+      // @todo Simplify with https://www.drupal.org/node/2548095
+      $base_url = str_replace('/update.php', '', \Drupal::request()->getBaseUrl());
+      $args = [
+        ':url' => Url::fromRoute('dblog.overview', [], ['query' => ['type' => ['update'], 'severity' => [RfcLogLevel::WARNING]]])
+          ->setOption('base_url', $base_url)
+          ->toString(TRUE)
+          ->getGeneratedUrl(),
+      ];
+      return new PluralTranslatableMarkup($count, 'Taxonomy terms have been converted to be revisionable. One term with data integrity issues was restored. More details have been <a href=":url">logged</a>.', 'Taxonomy terms have been converted to be revisionable. @count terms with data integrity issues were restored. More details have been <a href=":url">logged</a>.', $args);
+    }
+    else {
+      return new PluralTranslatableMarkup($count, 'Taxonomy terms have been converted to be revisionable. One term with data integrity issues was restored. More details have been logged.', 'Taxonomy terms have been converted to be revisionable. @count terms with data integrity issues were restored. More details have been logged.');
+    }
+  }
+  else {
+    return t('Taxonomy terms have been converted to be revisionable.');
+  }
+}
+
+/**
+ * Fixes recoverable data integrity issues in the "default_langcode" field.
+ *
+ * @param array $sandbox
+ *   The update sandbox array.
+ *
+ * @return bool
+ *   TRUE if the operation was finished, FALSE otherwise.
+ *
+ * @internal
+ */
+function _taxonomy_post_update_make_taxonomy_term_revisionable__fix_default_langcode(array &$sandbox) {
+  if (!empty($sandbox['data_fix']['default_langcode']['finished'])) {
+    return TRUE;
+  }
+
+  $storage = \Drupal::entityTypeManager()->getStorage('taxonomy_term');
+  if (!$storage instanceof TermStorage) {
+    $sandbox['data_fix']['default_langcode']['finished'] = TRUE;
+    return TRUE;
+  }
+  elseif (!isset($sandbox['data_fix']['default_langcode'])) {
+    $sandbox['data_fix']['default_langcode'] = [
+      'last_id' => 0,
+      'processed' => 0,
+    ];
+  }
+
+  $database = \Drupal::database();
+  $data_table_name = 'taxonomy_term_field_data';
+  $last_id = $sandbox['data_fix']['default_langcode']['last_id'];
+  $limit = Settings::get('update_sql_batch_size', 200);
+
+  // Detect records in the data table matching the base table language, but
+  // having the "default_langcode" flag set to with 0, which is not supported.
+  $query = $database->select($data_table_name, 'd');
+  $query->leftJoin('taxonomy_term_data', 'b', 'd.tid = b.tid AND d.langcode = b.langcode AND d.default_langcode = 0');
+  $result = $query->fields('d', ['tid', 'langcode'])
+    ->condition('d.tid', $last_id, '>')
+    ->isNotNull('b.tid')
+    ->orderBy('d.tid')
+    ->range(0, $limit)
+    ->execute();
+
+  foreach ($result as $record) {
+    $sandbox['data_fix']['default_langcode']['last_id'] = $record->tid;
+
+    // We need to exclude any term already having also a data table record with
+    // the "default_langcode" flag set to 1, because this is a data integrity
+    // issue that cannot be fixed automatically. However the latter will not
+    // make the update fail.
+    $has_default_langcode = (bool) $database->select($data_table_name, 'd')
+      ->fields('d', ['tid'])
+      ->condition('d.tid', $record->tid)
+      ->condition('d.default_langcode', 1)
+      ->range(0, 1)
+      ->execute()
+      ->fetchField();
+
+    if ($has_default_langcode) {
+      continue;
+    }
+
+    $database->update($data_table_name)
+      ->fields(['default_langcode' => 1])
+      ->condition('tid', $record->tid)
+      ->condition('langcode', $record->langcode)
+      ->execute();
+
+    $sandbox['data_fix']['default_langcode']['processed']++;
+
+    \Drupal::logger('update')
+      ->warning('The term with ID @id had data integrity issues and was restored.', ['@id' => $record->tid]);
+  }
+
+  $finished = $sandbox['data_fix']['default_langcode']['last_id'] === $last_id;
+  $sandbox['data_fix']['default_langcode']['finished'] = $finished;
+
+  return $finished;
 }

--- a/core/modules/taxonomy/tests/fixtures/update/drupal-8.taxonomy-term-null-data-3056543.php
+++ b/core/modules/taxonomy/tests/fixtures/update/drupal-8.taxonomy-term-null-data-3056543.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * @file
+ * Contains database additions to drupal-8.filled.standard.php.gz for testing
+ * the upgrade path of https://www.drupal.org/project/drupal/issues/3056543.
+ */
+
+use Drupal\Core\Database\Database;
+
+$connection = Database::getConnection();
+
+$connection->insert('taxonomy_term_data')
+  ->fields([
+    'tid' => 997,
+    'vid' => 'tags',
+    'uuid' => 'ea32f399-a53b-416c-81a9-e66204236c97',
+    'langcode' => 'en',
+  ])
+  ->execute();
+$connection->insert('taxonomy_term_field_data')
+  ->fields([
+    'tid' => 997,
+    'vid' => 'tags',
+    'langcode' => 'en',
+    'default_langcode' => 0,
+    'name' => 'tag997',
+    'weight' => 0,
+    'changed' => 1579555997,
+    'content_translation_status' => NULL,
+  ])
+  ->execute();
+$connection->insert('taxonomy_term_hierarchy')
+  ->fields([
+    'tid' => 997,
+    'parent' => 0,
+  ])
+  ->execute();
+
+$connection->insert('taxonomy_term_data')
+  ->fields([
+    'tid' => 998,
+    'vid' => 'tags',
+    'uuid' => 'ea32f399-a53b-416c-81a9-e66204236c98',
+    'langcode' => 'en',
+  ])
+  ->execute();
+$connection->insert('taxonomy_term_field_data')
+  ->fields([
+    'tid' => 998,
+    'vid' => 'tags',
+    'langcode' => 'en',
+    'default_langcode' => 0,
+    'name' => 'tag998',
+    'weight' => 0,
+    'changed' => 1579555998,
+    'content_translation_status' => NULL,
+  ])
+  ->execute();
+$connection->insert('taxonomy_term_hierarchy')
+  ->fields([
+    'tid' => 998,
+    'parent' => 0,
+  ])
+  ->execute();
+
+$connection->insert('taxonomy_term_data')
+  ->fields([
+    'tid' => 999,
+    'vid' => 'tags',
+    'uuid' => 'ea32f399-a53b-416c-81a9-e66204236c99',
+    'langcode' => 'en',
+  ])
+  ->execute();
+$connection->insert('taxonomy_term_field_data')
+  ->fields([
+    'tid' => 999,
+    'vid' => 'tags',
+    'langcode' => 'en',
+    'default_langcode' => 0,
+    'name' => 'tag999-en',
+    'weight' => 0,
+    'changed' => 1579555999,
+    'content_translation_status' => NULL,
+  ])
+  ->execute();
+$connection->insert('taxonomy_term_field_data')
+  ->fields([
+    'tid' => 999,
+    'vid' => 'tags',
+    'langcode' => 'es',
+    'default_langcode' => 1,
+    'name' => 'tag999-es',
+    'weight' => 0,
+    'changed' => 1579555999,
+    'content_translation_status' => NULL,
+  ])
+  ->execute();
+$connection->insert('taxonomy_term_hierarchy')
+  ->fields([
+    'tid' => 999,
+    'parent' => 0,
+  ])
+  ->execute();

--- a/core/modules/taxonomy/tests/modules/taxonomy_crud/taxonomy_crud.info.yml
+++ b/core/modules/taxonomy/tests/modules/taxonomy_crud/taxonomy_crud.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:taxonomy
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/taxonomy/tests/modules/taxonomy_term_stub_test/taxonomy_term_stub_test.info.yml
+++ b/core/modules/taxonomy/tests/modules/taxonomy_term_stub_test/taxonomy_term_stub_test.info.yml
@@ -8,7 +8,7 @@ dependencies:
   - drupal:taxonomy
   - drupal:migrate
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/taxonomy/tests/modules/taxonomy_test/taxonomy_test.info.yml
+++ b/core/modules/taxonomy/tests/modules/taxonomy_test/taxonomy_test.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:taxonomy
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/taxonomy/tests/modules/taxonomy_test_views/taxonomy_test_views.info.yml
+++ b/core/modules/taxonomy/tests/modules/taxonomy_test_views/taxonomy_test_views.info.yml
@@ -8,7 +8,7 @@ dependencies:
   - drupal:taxonomy
   - drupal:views
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/taxonomy/tests/modules/vocabulary_serialization_test/vocabulary_serialization_test.info.yml
+++ b/core/modules/taxonomy/tests/modules/vocabulary_serialization_test/vocabulary_serialization_test.info.yml
@@ -6,7 +6,7 @@ core: 8.x
 dependencies:
   - drupal:taxonomy
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/taxonomy/tests/src/Functional/Update/TaxonomyTermUpdatePathTest.php
+++ b/core/modules/taxonomy/tests/src/Functional/Update/TaxonomyTermUpdatePathTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\taxonomy\Functional\Update;
 
+use Drupal\Core\Database\Database;
 use Drupal\FunctionalTests\Update\UpdatePathTestBase;
 use Drupal\user\Entity\User;
 use Drupal\views\Entity\View;
@@ -22,6 +23,7 @@ class TaxonomyTermUpdatePathTest extends UpdatePathTestBase {
     $this->databaseDumpFiles = [
       __DIR__ . '/../../../../../system/tests/fixtures/update/drupal-8.filled.standard.php.gz',
       __DIR__ . '/../../../fixtures/update/drupal-8.views-taxonomy-term-publishing-status-2981887.php',
+      __DIR__ . '/../../../fixtures/update/drupal-8.taxonomy-term-null-data-3056543.php',
     ];
   }
 
@@ -151,7 +153,25 @@ class TaxonomyTermUpdatePathTest extends UpdatePathTestBase {
    * @see taxonomy_post_update_make_taxonomy_term_revisionable()
    */
   public function testConversionToRevisionable() {
+    // Set the batch size to 1 to test multiple steps.
+    drupal_rewrite_settings([
+      'settings' => [
+        'update_sql_batch_size' => (object) [
+          'value' => 1,
+          'required' => TRUE,
+        ],
+      ],
+    ]);
+
+    // Check that there are broken terms in the taxonomy tables, initially.
+    $this->assertTermName(997, '');
+    $this->assertTermName(998, '');
+    $this->assertTermName(999, 'tag999-es');
+
     $this->runUpdates();
+
+    // Check that the update function returned the expected message.
+    $this->assertSession()->pageTextContains('Taxonomy terms have been converted to be revisionable. 2 terms with data integrity issues were restored. More details have been logged.');
 
     // Check the database tables and the field storage definitions.
     $schema = \Drupal::database()->schema();
@@ -204,6 +224,64 @@ class TaxonomyTermUpdatePathTest extends UpdatePathTestBase {
     $this->assertEquals('article', $term->bundle());
     $this->assertEquals('Initial revision.', $term->getRevisionLogMessage());
     $this->assertTrue($term->isPublished());
+
+    // Check that two terms were restored and one was ignored. The latter cannot
+    // be manually restored, since we would end up with two data table records
+    // having "default_langcode" equalling 1, which would not make sense.
+    $this->assertTermName(997, 'tag997');
+    $this->assertTermName(998, 'tag998');
+    $this->assertTermName(999, 'tag999-es');
+  }
+
+  /**
+   * Assert that a term name matches the expectation.
+   *
+   * @param string $id
+   *   The term ID.
+   * @param string $expected_name
+   *   The expected term name.
+   */
+  protected function assertTermName($id, $expected_name) {
+    $database = \Drupal::database();
+    $query = $database->select('taxonomy_term_field_data', 'd');
+    $query->join('taxonomy_term_data', 't', 't.tid = d.tid AND d.default_langcode = 1');
+    $name = $query
+      ->fields('d', ['name'])
+      ->condition('d.tid', $id)
+      ->execute()
+      ->fetchField();
+
+    $this->assertSame($expected_name, $name ?: '');
+  }
+
+  /**
+   * Test the update hook requirements check for revisionable terms.
+   *
+   * @see taxonomy_post_update_make_taxonomy_term_revisionable()
+   * @see taxonomy_requirements()
+   */
+  public function testMissingDataUpdateRequirementsCheck() {
+    // Insert invalid data for a non-existent taxonomy term.
+    Database::getConnection()->insert('taxonomy_term_data')
+      ->fields([
+        'tid' => '6',
+        'vid' => 'tags',
+        'uuid' => 'd5fd282b-df66-4d50-b0d1-76bf9eede9c5',
+        'langcode' => 'en',
+      ])
+      ->execute();
+    $this->writeSettings([
+      'settings' => [
+        'update_free_access' => (object) [
+          'value' => TRUE,
+          'required' => TRUE,
+        ],
+      ],
+    ]);
+    $this->drupalGet($this->updateUrl);
+
+    $this->assertSession()->pageTextContains('Errors found');
+    $this->assertSession()->elementTextContains('css', '.system-status-report__entry--error', 'The make_taxonomy_term_revisionable database update cannot be run until the data has been fixed.');
   }
 
   /**

--- a/core/modules/telephone/telephone.info.yml
+++ b/core/modules/telephone/telephone.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:field
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/text/text.info.yml
+++ b/core/modules/text/text.info.yml
@@ -8,7 +8,7 @@ dependencies:
   - drupal:field
   - drupal:filter
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/toolbar/tests/modules/toolbar_disable_user_toolbar/toolbar_disable_user_toolbar.info.yml
+++ b/core/modules/toolbar/tests/modules/toolbar_disable_user_toolbar/toolbar_disable_user_toolbar.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/toolbar/tests/modules/toolbar_test/toolbar_test.info.yml
+++ b/core/modules/toolbar/tests/modules/toolbar_test/toolbar_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/toolbar/toolbar.info.yml
+++ b/core/modules/toolbar/toolbar.info.yml
@@ -7,7 +7,7 @@ package: Core
 dependencies:
   - drupal:breakpoint
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/tour/tests/tour_test/tour_test.info.yml
+++ b/core/modules/tour/tests/tour_test/tour_test.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:tour
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/tour/tour.info.yml
+++ b/core/modules/tour/tour.info.yml
@@ -5,7 +5,7 @@ package: Core
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/tracker/tests/modules/tracker_test_views/tracker_test_views.info.yml
+++ b/core/modules/tracker/tests/modules/tracker_test_views/tracker_test_views.info.yml
@@ -8,7 +8,7 @@ dependencies:
   - drupal:tracker
   - drupal:views
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/tracker/tracker.info.yml
+++ b/core/modules/tracker/tracker.info.yml
@@ -8,7 +8,7 @@ package: Core
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/update/tests/modules/aaa_update_test/aaa_update_test.info.yml
+++ b/core/modules/update/tests/modules/aaa_update_test/aaa_update_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/update/tests/modules/bbb_update_test/bbb_update_test.info.yml
+++ b/core/modules/update/tests/modules/bbb_update_test/bbb_update_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/update/tests/modules/ccc_update_test/ccc_update_test.info.yml
+++ b/core/modules/update/tests/modules/ccc_update_test/ccc_update_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/update/tests/modules/update_test/update_test.info.yml
+++ b/core/modules/update/tests/modules/update_test/update_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/update/tests/themes/update_test_basetheme/update_test_basetheme.info.yml
+++ b/core/modules/update/tests/themes/update_test_basetheme/update_test_basetheme.info.yml
@@ -4,7 +4,7 @@ description: 'Test theme which acts as a base theme for other test subthemes.'
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/update/tests/themes/update_test_subtheme/update_test_subtheme.info.yml
+++ b/core/modules/update/tests/themes/update_test_subtheme/update_test_subtheme.info.yml
@@ -5,7 +5,7 @@ description: 'Test theme which uses update_test_basetheme as the base theme.'
 core: 8.x
 base theme: update_test_basetheme
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/update/update.info.yml
+++ b/core/modules/update/update.info.yml
@@ -8,7 +8,7 @@ configure: update.settings
 dependencies:
   - drupal:file
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/user/tests/modules/user_access_test/user_access_test.info.yml
+++ b/core/modules/user/tests/modules/user_access_test/user_access_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/user/tests/modules/user_custom_phpass_params_test/user_custom_phpass_params_test.info.yml
+++ b/core/modules/user/tests/modules/user_custom_phpass_params_test/user_custom_phpass_params_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/user/tests/modules/user_form_test/user_form_test.info.yml
+++ b/core/modules/user/tests/modules/user_form_test/user_form_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/user/tests/modules/user_hooks_test/user_hooks_test.info.yml
+++ b/core/modules/user/tests/modules/user_hooks_test/user_hooks_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/user/tests/modules/user_test_views/user_test_views.info.yml
+++ b/core/modules/user/tests/modules/user_test_views/user_test_views.info.yml
@@ -8,7 +8,7 @@ dependencies:
   - drupal:user
   - drupal:views
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/user/tests/themes/user_test_theme/user_test_theme.info.yml
+++ b/core/modules/user/tests/themes/user_test_theme/user_test_theme.info.yml
@@ -4,7 +4,7 @@ description: 'Theme for testing the available fields in user twig template'
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/user/user.info.yml
+++ b/core/modules/user/user.info.yml
@@ -9,7 +9,7 @@ configure: user.admin_index
 dependencies:
   - drupal:system
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/views/tests/modules/action_bulk_test/action_bulk_test.info.yml
+++ b/core/modules/views/tests/modules/action_bulk_test/action_bulk_test.info.yml
@@ -8,7 +8,7 @@ dependencies:
   - drupal:views
   - drupal:node
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/views/tests/modules/user_batch_action_test/user_batch_action_test.info.yml
+++ b/core/modules/views/tests/modules/user_batch_action_test/user_batch_action_test.info.yml
@@ -8,7 +8,7 @@ dependencies:
   - views
   - user
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/views/tests/modules/views_entity_test/views_entity_test.info.yml
+++ b/core/modules/views/tests/modules/views_entity_test/views_entity_test.info.yml
@@ -8,7 +8,7 @@ dependencies:
   - drupal:views
   - drupal:entity_test
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/views/tests/modules/views_test_cacheable_metadata_calculation/views_test_cacheable_metadata_calculation.info.yml
+++ b/core/modules/views/tests/modules/views_test_cacheable_metadata_calculation/views_test_cacheable_metadata_calculation.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:views
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/views/tests/modules/views_test_config/views_test_config.info.yml
+++ b/core/modules/views/tests/modules/views_test_config/views_test_config.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:views
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/views/tests/modules/views_test_data/views_test_data.info.yml
+++ b/core/modules/views/tests/modules/views_test_data/views_test_data.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:views
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/views/tests/modules/views_test_formatter/views_test_formatter.info.yml
+++ b/core/modules/views/tests/modules/views_test_formatter/views_test_formatter.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:views
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/views/tests/modules/views_test_language/views_test_language.info.yml
+++ b/core/modules/views/tests/modules/views_test_language/views_test_language.info.yml
@@ -8,7 +8,7 @@ dependencies:
   - drupal:views
   - drupal:language
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/views/tests/modules/views_test_modal/views_test_modal.info.yml
+++ b/core/modules/views/tests/modules/views_test_modal/views_test_modal.info.yml
@@ -8,7 +8,7 @@ dependencies:
   - drupal:node
   - drupal:views
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/views/tests/themes/views_test_checkboxes_theme/views_test_checkboxes_theme.info.yml
+++ b/core/modules/views/tests/themes/views_test_checkboxes_theme/views_test_checkboxes_theme.info.yml
@@ -4,7 +4,7 @@ description: Theme for testing Views rendering of checkboxes.
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/views/tests/themes/views_test_theme/views_test_theme.info.yml
+++ b/core/modules/views/tests/themes/views_test_theme/views_test_theme.info.yml
@@ -4,7 +4,7 @@ description: Theme for testing Views functionality.
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/views/views.info.yml
+++ b/core/modules/views/views.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:filter
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/views_ui/tests/modules/views_ui_test/views_ui_test.info.yml
+++ b/core/modules/views_ui/tests/modules/views_ui_test/views_ui_test.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:views_ui
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/views_ui/tests/modules/views_ui_test_field/views_ui_test_field.info.yml
+++ b/core/modules/views_ui/tests/modules/views_ui_test_field/views_ui_test_field.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:views_ui
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/views_ui/views_ui.info.yml
+++ b/core/modules/views_ui/views_ui.info.yml
@@ -8,7 +8,7 @@ configure: entity.view.collection
 dependencies:
   - drupal:views
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/workflows/tests/modules/workflow_third_party_settings_test/workflow_third_party_settings_test.info.yml
+++ b/core/modules/workflows/tests/modules/workflow_third_party_settings_test/workflow_third_party_settings_test.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:workflows
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/workflows/tests/modules/workflow_type_test/workflow_type_test.info.yml
+++ b/core/modules/workflows/tests/modules/workflow_type_test/workflow_type_test.info.yml
@@ -7,7 +7,7 @@ core: 8.x
 dependencies:
   - drupal:workflows
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/workflows/workflows.info.yml
+++ b/core/modules/workflows/workflows.info.yml
@@ -6,7 +6,7 @@ core: 8.x
 package: Core
 configure: entity.workflow.collection
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/modules/workspaces/workspaces.info.yml
+++ b/core/modules/workspaces/workspaces.info.yml
@@ -8,7 +8,7 @@ configure: entity.workspace.collection
 dependencies:
  - drupal:user
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/profiles/demo_umami/demo_umami.info.yml
+++ b/core/profiles/demo_umami/demo_umami.info.yml
@@ -54,7 +54,7 @@ themes:
   - umami
 keep_english: true
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/profiles/demo_umami/modules/demo_umami_content/demo_umami_content.info.yml
+++ b/core/profiles/demo_umami/modules/demo_umami_content/demo_umami_content.info.yml
@@ -16,7 +16,7 @@ dependencies:
   - text
   - user
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/profiles/demo_umami/modules/demo_umami_tour/demo_umami_tour.info.yml
+++ b/core/profiles/demo_umami/modules/demo_umami_tour/demo_umami_tour.info.yml
@@ -7,7 +7,7 @@ dependencies:
   - node
   - tour
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/profiles/demo_umami/themes/umami/umami.info.yml
+++ b/core/profiles/demo_umami/themes/umami/umami.info.yml
@@ -33,7 +33,7 @@ regions:
   page_top: 'Page top' # Needed by Drupal Core
   page_bottom: 'Page bottom' # Needed by Drupal Core
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/profiles/minimal/minimal.info.yml
+++ b/core/profiles/minimal/minimal.info.yml
@@ -12,7 +12,7 @@ install:
 themes:
   - stark
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/profiles/standard/standard.info.yml
+++ b/core/profiles/standard/standard.info.yml
@@ -43,7 +43,7 @@ themes:
   - bartik
   - seven
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/profiles/testing/modules/drupal_system_cross_profile_test/drupal_system_cross_profile_test.info.yml
+++ b/core/profiles/testing/modules/drupal_system_cross_profile_test/drupal_system_cross_profile_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/profiles/testing/modules/drupal_system_listing_compatible_test/drupal_system_listing_compatible_test.info.yml
+++ b/core/profiles/testing/modules/drupal_system_listing_compatible_test/drupal_system_listing_compatible_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/profiles/testing/testing.info.yml
+++ b/core/profiles/testing/testing.info.yml
@@ -13,7 +13,7 @@ install:
 themes:
   - classy
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/profiles/testing_config_import/testing_config_import.info.yml
+++ b/core/profiles/testing_config_import/testing_config_import.info.yml
@@ -9,7 +9,7 @@ install:
 themes:
   - stark
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/profiles/testing_config_overrides/testing_config_overrides.info.yml
+++ b/core/profiles/testing_config_overrides/testing_config_overrides.info.yml
@@ -9,7 +9,7 @@ install:
   - language
   - tour
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/profiles/testing_install_profile_all_dependencies/testing_install_profile_all_dependencies.info.yml
+++ b/core/profiles/testing_install_profile_all_dependencies/testing_install_profile_all_dependencies.info.yml
@@ -11,7 +11,7 @@ install: []
 themes:
   - classy
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/profiles/testing_install_profile_dependencies/testing_install_profile_dependencies.info.yml
+++ b/core/profiles/testing_install_profile_dependencies/testing_install_profile_dependencies.info.yml
@@ -11,7 +11,7 @@ install:
 themes:
   - classy
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/profiles/testing_install_profile_dependencies_bc/testing_install_profile_dependencies_bc.info.yml
+++ b/core/profiles/testing_install_profile_dependencies_bc/testing_install_profile_dependencies_bc.info.yml
@@ -10,7 +10,7 @@ dependencies:
 themes:
   - classy
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/profiles/testing_missing_dependencies/testing_missing_dependencies.info.yml
+++ b/core/profiles/testing_missing_dependencies/testing_missing_dependencies.info.yml
@@ -12,7 +12,7 @@ install:
   - missing_module2
 keep_english: true
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/profiles/testing_multilingual/testing_multilingual.info.yml
+++ b/core/profiles/testing_multilingual/testing_multilingual.info.yml
@@ -8,7 +8,7 @@ install:
   - locale
   - tour
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/profiles/testing_multilingual_with_english/testing_multilingual_with_english.info.yml
+++ b/core/profiles/testing_multilingual_with_english/testing_multilingual_with_english.info.yml
@@ -8,7 +8,7 @@ install:
   - locale
 keep_english: true
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/profiles/testing_requirements/testing_requirements.info.yml
+++ b/core/profiles/testing_requirements/testing_requirements.info.yml
@@ -5,7 +5,7 @@ description: 'Profile for testing hook_requirements().'
 core: 8.x
 hidden: true
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/profiles/testing_site_config/testing_site_config.info.yml
+++ b/core/profiles/testing_site_config/testing_site_config.info.yml
@@ -5,7 +5,7 @@ description: 'Minimal profile for testing with default site config.'
 core: 8.x
 hidden: true
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/tests/Drupal/KernelTests/Core/Entity/FieldableEntityDefinitionUpdateTest.php
+++ b/core/tests/Drupal/KernelTests/Core/Entity/FieldableEntityDefinitionUpdateTest.php
@@ -94,6 +94,10 @@ class FieldableEntityDefinitionUpdateTest extends EntityKernelTestBase {
     $this->entityFieldManager = $this->container->get('entity_field.manager');
     $this->database = $this->container->get('database');
 
+    // Add a non-revisionable bundle field to test revision field table
+    // handling.
+    $this->addBundleField('string', FALSE, TRUE);
+
     // The 'changed' field type has a special behavior because it updates itself
     // automatically if any of the other field values of an entity have been
     // updated, so add it to the entity type that is being tested in order to
@@ -293,7 +297,9 @@ class FieldableEntityDefinitionUpdateTest extends EntityKernelTestBase {
     for ($i = $next_id; $i <= $next_id + 2; $i++) {
       $entity = $storage->create([
         'id' => $i,
+        'type' => 'test_bundle',
         'name' => 'test entity - ' . $i . ' - en',
+        'new_bundle_field' => 'bundle field - ' . $i . ' - en',
         'test_multiple_properties' => [
           'value1' => 'shared table - ' . $i . ' - value 1 - en',
           'value2' => 'shared table - ' . $i . ' - value 2 - en',
@@ -314,6 +320,7 @@ class FieldableEntityDefinitionUpdateTest extends EntityKernelTestBase {
       if ($translatable) {
         $translation = $entity->addTranslation('ro', [
           'name' => 'test entity - ' . $i . ' - ro',
+          'new_bundle_field' => 'bundle field - ' . $i . ' - ro',
           'test_multiple_properties' => [
             'value1' => 'shared table - ' . $i . ' - value 1 - ro',
             'value2' => 'shared table - ' . $i . ' - value 2 - ro',
@@ -337,6 +344,7 @@ class FieldableEntityDefinitionUpdateTest extends EntityKernelTestBase {
         // Create a new pending revision.
         $revision_2 = $storage->createRevision($entity, FALSE);
         $revision_2->name = 'test entity - ' . $i . ' - en - rev2';
+        $revision_2->new_bundle_field = 'bundle field - ' . $i . ' - en - rev2';
         $revision_2->test_multiple_properties->value1 = 'shared table - ' . $i . ' - value 1 - en - rev2';
         $revision_2->test_multiple_properties->value2 = 'shared table - ' . $i . ' - value 2 - en - rev2';
         $revision_2->test_multiple_properties_multiple_values[0]->value1 = 'dedicated table - ' . $i . ' - delta 0 - value 1 - en - rev2';
@@ -348,6 +356,7 @@ class FieldableEntityDefinitionUpdateTest extends EntityKernelTestBase {
         if ($translatable) {
           $revision_2_translation = $storage->createRevision($entity->getTranslation('ro'), FALSE);
           $revision_2_translation->name = 'test entity - ' . $i . ' - ro - rev2';
+          $revision_2->new_bundle_field = 'bundle field - ' . $i . ' - ro - rev2';
           $revision_2->test_multiple_properties->value1 = 'shared table - ' . $i . ' - value 1 - ro - rev2';
           $revision_2->test_multiple_properties->value2 = 'shared table - ' . $i . ' - value 2 - ro - rev2';
           $revision_2_translation->test_multiple_properties_multiple_values[0]->value1 = 'dedicated table - ' . $i . ' - delta 0 - value 1 - ro - rev2';
@@ -374,6 +383,7 @@ class FieldableEntityDefinitionUpdateTest extends EntityKernelTestBase {
     foreach ($entities as $entity_id => $entity) {
       /** @var \Drupal\Core\Entity\ContentEntityInterface $entity */
       $this->assertEquals("test entity - {$entity->id()} - en", $entity->label());
+      $this->assertEquals("bundle field - {$entity->id()} - en", $entity->new_bundle_field->value);
       $this->assertEquals("shared table - {$entity->id()} - value 1 - en", $entity->test_multiple_properties->value1);
       $this->assertEquals("shared table - {$entity->id()} - value 2 - en", $entity->test_multiple_properties->value2);
       $this->assertEquals("dedicated table - {$entity->id()} - delta 0 - value 1 - en", $entity->test_multiple_properties_multiple_values[0]->value1);
@@ -384,6 +394,7 @@ class FieldableEntityDefinitionUpdateTest extends EntityKernelTestBase {
       if ($translatable) {
         $translation = $entity->getTranslation('ro');
         $this->assertEquals("test entity - {$translation->id()} - ro", $translation->label());
+        $this->assertEquals("bundle field - {$entity->id()} - ro", $translation->new_bundle_field->value);
         $this->assertEquals("shared table - {$translation->id()} - value 1 - ro", $translation->test_multiple_properties->value1);
         $this->assertEquals("shared table - {$translation->id()} - value 2 - ro", $translation->test_multiple_properties->value2);
         $this->assertEquals("dedicated table - {$translation->id()} - delta 0 - value 1 - ro", $translation->test_multiple_properties_multiple_values[0]->value1);
@@ -402,6 +413,7 @@ class FieldableEntityDefinitionUpdateTest extends EntityKernelTestBase {
         /** @var \Drupal\Core\Entity\ContentEntityInterface $revision */
         $revision_label = $revision->isDefaultRevision() ? NULL : ' - rev2';
         $this->assertEquals("test entity - {$revision->id()} - en{$revision_label}", $revision->label());
+        $this->assertEquals("bundle field - {$revision->id()} - en{$revision_label}", $revision->new_bundle_field->value);
         $this->assertEquals("shared table - {$revision->id()} - value 1 - en{$revision_label}", $revision->test_multiple_properties->value1);
         $this->assertEquals("shared table - {$revision->id()} - value 2 - en{$revision_label}", $revision->test_multiple_properties->value2);
         $this->assertEquals("dedicated table - {$revision->id()} - delta 0 - value 1 - en{$revision_label}", $revision->test_multiple_properties_multiple_values[0]->value1);
@@ -412,6 +424,7 @@ class FieldableEntityDefinitionUpdateTest extends EntityKernelTestBase {
         if ($translatable) {
           $translation = $revision->getTranslation('ro');
           $this->assertEquals("test entity - {$translation->id()} - ro{$revision_label}", $translation->label());
+          $this->assertEquals("bundle field - {$entity->id()} - ro{$revision_label}", $translation->new_bundle_field->value);
           $this->assertEquals("shared table - {$revision->id()} - value 1 - ro{$revision_label}", $translation->test_multiple_properties->value1);
           $this->assertEquals("shared table - {$revision->id()} - value 2 - ro{$revision_label}", $translation->test_multiple_properties->value2);
           $this->assertEquals("dedicated table - {$translation->id()} - delta 0 - value 1 - ro{$revision_label}", $translation->test_multiple_properties_multiple_values[0]->value1);
@@ -456,6 +469,8 @@ class FieldableEntityDefinitionUpdateTest extends EntityKernelTestBase {
     else {
       $this->assertNonRevisionableAndNonTranslatable();
     }
+
+    $this->assertBundleFieldSchema($revisionable);
   }
 
   /**
@@ -589,6 +604,26 @@ class FieldableEntityDefinitionUpdateTest extends EntityKernelTestBase {
   }
 
   /**
+   * Asserts that the bundle field schema is correct.
+   *
+   * @param bool $revisionable
+   *   Whether the entity type is revisionable or not.
+   */
+  protected function assertBundleFieldSchema($revisionable) {
+    $entity_type_id = 'entity_test_update';
+    $field_storage_definition = $this->entityFieldManager->getFieldStorageDefinitions($entity_type_id)['new_bundle_field'];
+    $database_schema = $this->database->schema();
+    /** @var \Drupal\Core\Entity\Sql\DefaultTableMapping $table_mapping */
+    $table_mapping = $this->entityTypeManager
+      ->getStorage($entity_type_id)
+      ->getTableMapping();
+    $this->assertTrue($database_schema->tableExists($table_mapping->getDedicatedDataTableName($field_storage_definition)));
+    if ($revisionable) {
+      $this->assertTrue($database_schema->tableExists($table_mapping->getDedicatedRevisionTableName($field_storage_definition)));
+    }
+  }
+
+  /**
    * Asserts that the backup tables have been kept after a successful update.
    */
   protected function assertBackupTables() {
@@ -616,7 +651,7 @@ class FieldableEntityDefinitionUpdateTest extends EntityKernelTestBase {
     $this->insertData(FALSE, TRUE);
 
     $tables = $schema->findTables('old_%');
-    $this->assertCount(3, $tables);
+    $this->assertCount(4, $tables);
     foreach ($tables as $table) {
       $schema->dropTable($table);
     }
@@ -781,7 +816,7 @@ class FieldableEntityDefinitionUpdateTest extends EntityKernelTestBase {
 
     // Check that backup tables are kept by default.
     $tables = $schema->findTables('old_%');
-    $this->assertCount(3, $tables);
+    $this->assertCount(4, $tables);
     foreach ($tables as $table) {
       $schema->dropTable($table);
     }

--- a/core/tests/Drupal/KernelTests/Core/Update/CompatibilityFixTest.php
+++ b/core/tests/Drupal/KernelTests/Core/Update/CompatibilityFixTest.php
@@ -8,6 +8,7 @@ use Drupal\KernelTests\KernelTestBase;
  * Tests that extensions that are incompatible with the current core version are disabled.
  *
  * @group Update
+ * @group legacy
  */
 class CompatibilityFixTest extends KernelTestBase {
 
@@ -21,6 +22,9 @@ class CompatibilityFixTest extends KernelTestBase {
     require_once $this->root . '/core/includes/update.inc';
   }
 
+  /**
+   * @expectedDeprecation update_fix_compatibility() is deprecated in Drupal 8.8.4 and will be removed before Drupal 9.0.0. There is no replacement. See https://www.drupal.org/node/3026100
+   */
   public function testFixCompatibility() {
     $extension_config = \Drupal::configFactory()->getEditable('core.extension');
 

--- a/core/tests/Drupal/Tests/Core/Extension/ExtensionListTest.php
+++ b/core/tests/Drupal/Tests/Core/Extension/ExtensionListTest.php
@@ -206,9 +206,77 @@ class ExtensionListTest extends UnitTestCase {
   }
 
   /**
-   * @return \Drupal\Tests\Core\Extension\TestExtension
+   * @covers ::checkIncompatibility
+   *
+   * @dataProvider providerCheckIncompatibility
    */
-  protected function setupTestExtensionList($extension_names = ['test_name']) {
+  public function testCheckIncompatibility($additional_settings, $expected) {
+    $test_extension_list = $this->setupTestExtensionList(['test_name'], $additional_settings);
+    $this->assertSame($expected, $test_extension_list->checkIncompatibility('test_name'));
+  }
+
+  /**
+   * DataProvider for testCheckIncompatibility().
+   */
+  public function providerCheckIncompatibility() {
+    return [
+      'core_incompatible true' => [
+        [
+          'core_incompatible' => TRUE,
+        ],
+        TRUE,
+      ],
+      'core_incompatible false' => [
+        [
+          'core_incompatible' => FALSE,
+        ],
+        FALSE,
+      ],
+      'PHP 1, core_incompatible FALSE' => [
+        [
+          'core_incompatible' => FALSE,
+          'php' => 1,
+        ],
+        FALSE,
+      ],
+      'PHP 1000000000000, core_incompatible FALSE' => [
+        [
+          'core_incompatible' => FALSE,
+          'php' => 1000000000000,
+        ],
+        TRUE,
+      ],
+      'PHP 1, core_incompatible TRUE' => [
+        [
+          'core_incompatible' => TRUE,
+          'php' => 1,
+        ],
+        TRUE,
+      ],
+      'PHP 1000000000000, core_incompatible TRUE' => [
+        [
+          'core_incompatible' => TRUE,
+          'php' => 1000000000000,
+        ],
+        TRUE,
+      ],
+    ];
+  }
+
+  /**
+   * Sets up an a test extension list.
+   *
+   * @param string[] $extension_names
+   *   The names of the extensions to create.
+   * @param mixed[] $additional_info_values
+   *   The additional values to add to extensions info.yml files. These values
+   *   will be encoded using '\Drupal\Component\Serialization\Yaml::encode()'.
+   *   The array keys should be valid top level yaml file keys.
+   *
+   * @return \Drupal\Tests\Core\Extension\TestExtension
+   *   The test extension list.
+   */
+  protected function setupTestExtensionList(array $extension_names = ['test_name'], array $additional_info_values = []) {
     vfsStream::setup('drupal_root');
 
     $folders = ['example' => []];
@@ -217,7 +285,7 @@ class ExtensionListTest extends UnitTestCase {
         'name' => 'test name',
         'type' => 'test_extension',
         'core' => '8.x',
-      ]);
+      ] + $additional_info_values);
     }
     vfsStream::create($folders);
     foreach ($extension_names as $extension_name) {

--- a/core/tests/Drupal/Tests/Core/Extension/modules/module_handler_test/module_handler_test.info.yml
+++ b/core/tests/Drupal/Tests/Core/Extension/modules/module_handler_test/module_handler_test.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/tests/Drupal/Tests/Core/Extension/modules/module_handler_test_added/module_handler_test_added.info.yml
+++ b/core/tests/Drupal/Tests/Core/Extension/modules/module_handler_test_added/module_handler_test_added.info.yml
@@ -6,7 +6,7 @@ package: Testing
 core: 8.x
 hidden: true
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/tests/Drupal/Tests/Core/Extension/modules/module_handler_test_all1/module_handler_test_all1.info.yml
+++ b/core/tests/Drupal/Tests/Core/Extension/modules/module_handler_test_all1/module_handler_test_all1.info.yml
@@ -6,7 +6,7 @@ package: Testing
 core: 8.x
 hidden: true
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/tests/Drupal/Tests/Core/Extension/modules/module_handler_test_all2/module_handler_test_all2.info.yml
+++ b/core/tests/Drupal/Tests/Core/Extension/modules/module_handler_test_all2/module_handler_test_all2.info.yml
@@ -6,7 +6,7 @@ package: Testing
 core: 8.x
 hidden: true
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/tests/Drupal/Tests/Core/Extension/modules/module_handler_test_no_hook/module_handler_test_no_hook.info.yml
+++ b/core/tests/Drupal/Tests/Core/Extension/modules/module_handler_test_no_hook/module_handler_test_no_hook.info.yml
@@ -5,7 +5,7 @@ package: Testing
 # version: VERSION
 core: 8.x
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/tests/Drupal/Tests/Core/Form/FormStateDecoratorBaseTest.php
+++ b/core/tests/Drupal/Tests/Core/Form/FormStateDecoratorBaseTest.php
@@ -7,6 +7,7 @@ use Drupal\Core\Form\FormStateDecoratorBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 use Drupal\Tests\UnitTestCase;
+use Prophecy\Argument;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -1440,7 +1441,7 @@ class FormStateDecoratorBaseTest extends UnitTestCase {
    * @param callable $prepared_callback
    */
   public function testPrepareCallback($unprepared_callback, callable $prepared_callback) {
-    $this->decoratedFormState->prepareCallback($unprepared_callback)
+    $this->decoratedFormState->prepareCallback(Argument::is($unprepared_callback))
       ->willReturn($prepared_callback)
       ->shouldBeCalled();
 

--- a/core/tests/Drupal/Tests/RequirementsPageTrait.php
+++ b/core/tests/Drupal/Tests/RequirementsPageTrait.php
@@ -12,7 +12,8 @@ trait RequirementsPageTrait {
    */
   protected function updateRequirementsProblem() {
     // Assert a warning is shown on older test environments.
-    if (version_compare(phpversion(), DRUPAL_MINIMUM_SUPPORTED_PHP) < 0) {
+    $links = $this->getSession()->getPage()->findAll('named', ['link', 'try again']);
+    if ($links && version_compare(phpversion(), DRUPAL_MINIMUM_SUPPORTED_PHP) < 0) {
       $this->assertNoText('Errors found');
       $this->assertWarningSummaries(['PHP']);
       $this->clickLink('try again');

--- a/core/themes/bartik/bartik.info.yml
+++ b/core/themes/bartik/bartik.info.yml
@@ -46,7 +46,7 @@ regions:
   footer_fourth: 'Footer fourth'
   footer_fifth: 'Footer fifth'
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/themes/classy/classy.info.yml
+++ b/core/themes/classy/classy.info.yml
@@ -23,7 +23,7 @@ libraries-extend:
   core/drupal.progress:
     - classy/progress
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/themes/engines/twig/twig.info.yml
+++ b/core/themes/engines/twig/twig.info.yml
@@ -4,7 +4,7 @@ core: 8.x
 # version: VERSION
 package: Core
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/themes/seven/seven.info.yml
+++ b/core/themes/seven/seven.info.yml
@@ -71,7 +71,7 @@ regions:
 regions_hidden:
   - sidebar_first
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/themes/stable/stable.info.yml
+++ b/core/themes/stable/stable.info.yml
@@ -299,7 +299,7 @@ libraries-override:
         css/views_ui.admin.theme.css: css/views_ui/views_ui.admin.theme.css
         css/views_ui.contextual.css: css/views_ui/views_ui.contextual.css
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700

--- a/core/themes/stark/stark.info.yml
+++ b/core/themes/stark/stark.info.yml
@@ -6,7 +6,7 @@ package: Core
 core: 8.x
 base theme: false
 
-# Information added by Drupal.org packaging script on 2020-03-18
-version: '8.7.12'
+# Information added by Drupal.org packaging script on 2020-05-20
+version: '8.7.14'
 project: 'drupal'
-datestamp: 1584552285
+datestamp: 1589988700


### PR DESCRIPTION
fails on db update unless we add `$settings['install_profile'] = 'standard';` in settings.php when running updatedb command.